### PR TITLE
veriform.rs: Initial encoder

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -45,7 +45,7 @@ jobs:
       - name: Install target
         run: rustup target add ${{ matrix.target }}
 
-      - name: Run cargo build (core)
+      - name: Run cargo build --target ${{ matrix.target }}
         working-directory: veriform.rs
         env:
           RUSTFLAGS: -D warnings
@@ -125,7 +125,7 @@ jobs:
           toolchain: ${{ matrix.toolchain }}
           override: true
 
-      - name: Run cargo test
+      - name: Run cargo test --release
         uses: actions-rs/cargo@v1
         env:
           CARGO_INCREMENTAL: 0
@@ -133,6 +133,15 @@ jobs:
         with:
           command: test
           args: --release
+
+      - name: Run cargo test --all-features --release
+        uses: actions-rs/cargo@v1
+        env:
+          CARGO_INCREMENTAL: 0
+          RUSTFLAGS: -D warnings
+        with:
+          command: test
+          args: --all-features --release
 
   fmt:
     name: Rustfmt

--- a/veriform.rs/Cargo.toml
+++ b/veriform.rs/Cargo.toml
@@ -12,3 +12,6 @@ keywords    = ["authentication", "cryptography", "security", "serialization", "m
 
 [dependencies]
 vint64 = "0.1"
+
+[features]
+std = []

--- a/veriform.rs/src/encoder.rs
+++ b/veriform.rs/src/encoder.rs
@@ -1,0 +1,161 @@
+//! Veriform encoder
+
+use crate::{
+    field::{Header, Tag, WireType},
+    Error,
+};
+
+/// Veriform encoder
+pub struct Encoder<'a> {
+    /// Mutable buffer containing the message
+    buffer: &'a mut [u8],
+
+    /// Running total length of the message
+    length: usize,
+}
+
+impl<'a> Encoder<'a> {
+    /// Create a new [`Encoder`] which writes into the provided buffer
+    pub fn new(buffer: &'a mut [u8]) -> Self {
+        Self { buffer, length: 0 }
+    }
+
+    /// Write a field containing an unsigned 64-bit integer
+    pub fn uint64(&mut self, tag: Tag, value: u64) -> Result<(), Error> {
+        self.write_header(tag, WireType::UInt64)?;
+        self.write(vint64::encode(value))?;
+        Ok(())
+    }
+
+    /// Write a field containing a signed 64-bit integer
+    pub fn sint64(&mut self, tag: Tag, value: i64) -> Result<(), Error> {
+        self.write_header(tag, WireType::SInt64)?;
+        self.write(vint64::encode_signed(value))?;
+        Ok(())
+    }
+
+    /// Write a field containing bytes
+    pub fn bytes(&mut self, tag: Tag, bytes: &[u8]) -> Result<(), Error> {
+        self.write_header(tag, WireType::Bytes)?;
+        self.write(vint64::encode(bytes.len() as u64))?;
+        self.write(bytes)?;
+        Ok(())
+    }
+
+    /// Write a nested message. Length must be known in advance.
+    ///
+    /// Calls the given function to actually write the message, passing the
+    /// current buffer to the other function, and replacing it with the newly
+    /// returned slice upon success.
+    pub fn message<F>(&mut self, tag: Tag, length: usize, f: F) -> Result<(), Error>
+    where
+        F: FnOnce(&mut [u8]) -> Result<(), Error>,
+    {
+        self.write_header(tag, WireType::Message)?;
+        self.write(vint64::encode(length as u64))?;
+
+        // Ensure there's remaining space in the buffer
+        if length > (self.buffer.len() - self.length) {
+            return Err(Error::Length);
+        }
+
+        let new_length = self.length.checked_add(length).unwrap();
+        f(&mut self.buffer[self.length..new_length])?;
+        self.length = new_length;
+
+        Ok(())
+    }
+
+    /// Finish constructing a message, returning a slice of the buffer
+    /// containing the serialized message
+    pub fn finish(self) -> &'a mut [u8] {
+        &mut self.buffer[..self.length]
+    }
+
+    /// Write a field header to the underlying buffer
+    fn write_header(&mut self, tag: Tag, wire_type: WireType) -> Result<(), Error> {
+        self.write(Header { tag, wire_type }.encode())
+    }
+
+    /// Write the given bytes to the underlying buffer.
+    ///
+    /// Returns an error if the buffer has insufficient space.
+    fn write(&mut self, bytes: impl AsRef<[u8]>) -> Result<(), Error> {
+        let bytes = bytes.as_ref();
+
+        // Ensure there's remaining space in the buffer
+        if bytes.len() > (self.buffer.len() - self.length) {
+            return Err(Error::Length);
+        }
+
+        let new_length = self.length.checked_add(bytes.len()).unwrap();
+        self.buffer[self.length..new_length].copy_from_slice(bytes);
+        self.length = new_length;
+
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::Encoder;
+    use crate::{
+        decoder::{Decoder, Event},
+        field::WireType,
+    };
+
+    macro_rules! try_decode {
+        ($decoder:expr, $input:expr, $event:path) => {
+            match $decoder.decode($input).unwrap() {
+                Some($event(event)) => event,
+                other => panic!(
+                    concat!("expected ", stringify!($event), ", got: {:?}"),
+                    other
+                ),
+            }
+        };
+    }
+
+    #[test]
+    fn encode_then_decode() {
+        let mut buffer = [0u8; 1024];
+        let mut encoder = Encoder::new(&mut buffer);
+        encoder.uint64(1, 42).unwrap();
+        encoder.sint64(2, -1).unwrap();
+        encoder.bytes(3, b"foobar").unwrap();
+        let length = encoder.finish().len();
+        let mut message = &buffer[..length];
+
+        let mut decoder = Decoder::new();
+        let header = try_decode!(decoder, &mut message, Event::FieldHeader);
+        assert_eq!(header.tag, 1);
+        assert_eq!(header.wire_type, WireType::UInt64);
+
+        let value = try_decode!(decoder, &mut message, Event::UInt64);
+        assert_eq!(value, 42);
+
+        let header = try_decode!(decoder, &mut message, Event::FieldHeader);
+        assert_eq!(header.tag, 2);
+        assert_eq!(header.wire_type, WireType::SInt64);
+
+        let value = try_decode!(decoder, &mut message, Event::SInt64);
+        assert_eq!(value, -1);
+
+        let header = try_decode!(decoder, &mut message, Event::FieldHeader);
+        assert_eq!(header.tag, 3);
+        assert_eq!(header.wire_type, WireType::Bytes);
+
+        let msg_len = try_decode!(decoder, &mut message, Event::BytesLength);
+        assert_eq!(msg_len, 6);
+
+        match decoder.decode(&mut message).unwrap() {
+            Some(Event::BytesChunk { bytes, remaining }) => {
+                assert_eq!(remaining, 0);
+                assert_eq!(bytes, b"foobar");
+            }
+            other => panic!(concat!("expected Event::BytesChunk, got: {:?}"), other),
+        };
+
+        assert_eq!(message.len(), 0);
+    }
+}

--- a/veriform.rs/src/error.rs
+++ b/veriform.rs/src/error.rs
@@ -1,0 +1,33 @@
+//! Error type
+
+use core::fmt::{self, Display};
+
+/// Error type
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum Error {
+    /// Malformed data encountered while decoding
+    Decode,
+
+    /// Operation failed or is in a bad state
+    Failed,
+
+    /// Length is incorrect/insufficient
+    Length,
+
+    /// Invalid wire type
+    WireType,
+}
+
+impl Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(match self {
+            Error::Decode => "decode error",
+            Error::Failed => "operation failed",
+            Error::Length => "bad length",
+            Error::WireType => "invalid wire type",
+        })
+    }
+}
+
+#[cfg(feature = "std")]
+impl std::error::Error for Error {}

--- a/veriform.rs/src/field.rs
+++ b/veriform.rs/src/field.rs
@@ -2,15 +2,26 @@
 
 use crate::Error;
 use core::convert::TryFrom;
+use vint64::Vint64;
+
+/// Tag which identifies a field
+pub type Tag = u64;
 
 /// Field headers
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
 pub struct Header {
     /// Tag which identifies the field
-    pub tag: u64,
+    pub tag: Tag,
 
     /// Encoded value type for the field
     pub wire_type: WireType,
+}
+
+impl Header {
+    /// Encode this header value as a `Vint64`
+    pub fn encode(self) -> Vint64 {
+        vint64::encode(self.tag << 3 | self.wire_type as u64)
+    }
 }
 
 impl TryFrom<u64> for Header {
@@ -25,6 +36,7 @@ impl TryFrom<u64> for Header {
 
 /// Wire type identifiers for Veriform types
 #[derive(Copy, Clone, Debug, Eq, PartialEq, PartialOrd, Ord)]
+#[repr(u64)]
 pub enum WireType {
     /// 64-bit unsigned integer
     UInt64 = 0,
@@ -48,7 +60,7 @@ impl TryFrom<u64> for WireType {
             1 => Ok(WireType::SInt64),
             2 => Ok(WireType::Message),
             3 => Ok(WireType::Bytes),
-            _ => Err(Error),
+            _ => Err(Error::WireType),
         }
     }
 }

--- a/veriform.rs/src/lib.rs
+++ b/veriform.rs/src/lib.rs
@@ -6,12 +6,12 @@
 #![forbid(unsafe_code)]
 #![warn(missing_docs, rust_2018_idioms, unused_qualifications)]
 
+#[cfg(feature = "std")]
+extern crate std;
+
 pub mod decoder;
+pub mod encoder;
+pub mod error;
 pub mod field;
 
-pub use crate::decoder::Decoder;
-
-/// Error type
-// TODO(tarcieri): capture more info?
-#[derive(Debug)]
-pub struct Error;
+pub use crate::{decoder::Decoder, encoder::Encoder, error::Error};


### PR DESCRIPTION
Initial message encoding support, which writes into a mutably borrowed byte slice.

This includes initial support for writing nested messages, although it needs their lengths to be known in advance.