### PR TITLE
veriform.rs: Add initial Message trait

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -125,6 +125,14 @@ jobs:
           toolchain: ${{ matrix.toolchain }}
           override: true
 
+      - name: Run cargo test --no-default-features --lib
+        env:
+          CARGO_INCREMENTAL: 0
+          RUSTFLAGS: -D warnings
+        run: |
+          cd veriform.rs
+          cargo test --no-default-features --release
+
       - name: Run cargo test --release
         uses: actions-rs/cargo@v1
         env:
@@ -133,15 +141,6 @@ jobs:
         with:
           command: test
           args: --release
-
-      - name: Run cargo test --all-features --release
-        uses: actions-rs/cargo@v1
-        env:
-          CARGO_INCREMENTAL: 0
-          RUSTFLAGS: -D warnings
-        with:
-          command: test
-          args: --all-features --release
 
   fmt:
     name: Rustfmt

--- a/veriform.rs/Cargo.toml
+++ b/veriform.rs/Cargo.toml
@@ -14,4 +14,6 @@ keywords    = ["authentication", "cryptography", "security", "serialization", "m
 vint64 = "0.1"
 
 [features]
-std = []
+default = ["std"]
+alloc = []
+std = ["alloc"]

--- a/veriform.rs/src/lib.rs
+++ b/veriform.rs/src/lib.rs
@@ -1,10 +1,17 @@
-//! veriform.rs: Cryptographically verifiable data serialization format
+//! Veriform: cryptographically verifiable data serialization format
 //! inspired by Protocol Buffers.
+//!
+//! This crate provides a `no_std`-friendly implementation of the format
+//! with a zero-copy pull parser.
 
 #![no_std]
-#![doc(html_root_url = "https://docs.rs/vint64/0.0.0")]
+#![doc(html_root_url = "https://docs.rs/veriform/0.0.0")]
 #![forbid(unsafe_code)]
 #![warn(missing_docs, rust_2018_idioms, unused_qualifications)]
+
+#[cfg(feature = "alloc")]
+#[macro_use]
+extern crate alloc;
 
 #[cfg(feature = "std")]
 extern crate std;
@@ -13,5 +20,6 @@ pub mod decoder;
 pub mod encoder;
 pub mod error;
 pub mod field;
+pub mod message;
 
-pub use crate::{decoder::Decoder, encoder::Encoder, error::Error};
+pub use crate::{decoder::Decoder, encoder::Encoder, error::Error, message::Message};

--- a/veriform.rs/src/message.rs
+++ b/veriform.rs/src/message.rs
@@ -1,0 +1,34 @@
+//! Veriform messages
+
+// Conceptually inspired by the `prost::Message` trait:
+// <https://github.com/danburkert/prost/blob/master/src/message.rs>
+//
+// Copyright (c) 2017 Dan Burkert and released under the Apache 2.0 license.
+
+use crate::Error;
+
+#[cfg(feature = "alloc")]
+use alloc::vec::Vec;
+
+/// Veriform message
+pub trait Message {
+    /// Decode a Veriform message contained in the provided slice.
+    fn decode(bytes: impl AsRef<[u8]>) -> Result<Self, Error>
+    where
+        Self: Sized;
+
+    /// Encode this message as Veriform into the provided buffer, returning
+    /// a slice containing the encoded message on success.
+    fn encode(&self, buffer: &mut [u8]) -> Result<&mut [u8], Error>;
+
+    /// Get the length of a message after being encoded as Veriform.
+    fn encoded_len(&self) -> usize;
+
+    /// Encode this message as Veriform, returning a byte vector on success.
+    #[cfg(feature = "alloc")]
+    fn encode_vec(&self) -> Result<Vec<u8>, Error> {
+        let mut encoded = vec![0; self.encoded_len()];
+        self.encode(&mut encoded)?;
+        Ok(encoded)
+    }
+}


### PR DESCRIPTION
Somewhat inspired by a similar trait from `prost`:

https://docs.rs/prost/latest/prost/trait.Message.html