### PR TITLE
vint64.rs v0.2.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -535,7 +535,7 @@ checksum = "914b1a6776c4c929a602fafd8bc742e06365d4bcbe48c30f9cca5824f70dc9dd"
 
 [[package]]
 name = "vint64"
-version = "0.1.2"
+version = "0.2.0"
 dependencies = [
  "criterion",
  "criterion-cycles-per-byte",

--- a/veriform.rs/Cargo.toml
+++ b/veriform.rs/Cargo.toml
@@ -8,10 +8,10 @@ repository  = "https://github.com/clasp-lang/veriform"
 readme      = "README.md"
 edition     = "2018"
 categories  = ["authentication", "cryptography", "encoding"]
-keywords    = ["authentication", "cryptography", "security", "serialization", "merkle"]
+keywords    = ["hashing", "merkle", "protobufs", "security", "serialization"]
 
 [dependencies]
-vint64 = { version = "0.1", path = "vint64" }
+vint64 = { version = "0.2", path = "vint64" }
 
 [features]
 default = ["std"]

--- a/veriform.rs/vint64/CHANGES.md
+++ b/veriform.rs/vint64/CHANGES.md
@@ -1,3 +1,14 @@
+## [0.2.0] (2020-02-14)
+
+- Add `VInt64::len()` method ([#63])
+- Rename `Vint64` -> `VInt64` ([#62])
+- Relocate crate into the Veriform git repo ([#61])
+
+[0.2.0]: https://github.com/clasp-lang/veriform/pull/64
+[#63]: https://github.com/clasp-lang/veriform/pull/63
+[#62]: https://github.com/clasp-lang/veriform/pull/62
+[#61]: https://github.com/clasp-lang/veriform/pull/61
+
 ## 0.1.2 (2020-01-31)
 
 - More documentation improvements

--- a/veriform.rs/vint64/Cargo.toml
+++ b/veriform.rs/vint64/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name        = "vint64"
 description = "Simple and efficient variable-length integer encoding"
-version     = "0.1.2" # Also update html_root_url in lib.rs when bumping this
+version     = "0.2.0" # Also update html_root_url in lib.rs when bumping this
 authors     = ["Tony Arcieri <tony@iqlusion.io>"]
 license     = "Apache-2.0"
 edition     = "2018"

--- a/veriform.rs/vint64/src/lib.rs
+++ b/veriform.rs/vint64/src/lib.rs
@@ -73,7 +73,7 @@
 //! [Matroska]: https://www.matroska.org/
 
 #![no_std]
-#![doc(html_root_url = "https://docs.rs/vint64/0.1.2")]
+#![doc(html_root_url = "https://docs.rs/vint64/0.2.0")]
 #![forbid(unsafe_code)]
 #![warn(missing_docs, rust_2018_idioms, unused_qualifications)]
 


### PR DESCRIPTION
- Add `VInt64::len()` method ([#63])
- Rename `Vint64` -> `VInt64` ([#62])
- Relocate crate into the Veriform git repo ([#61])

[#63]: https://github.com/clasp-lang/veriform/pull/63
[#62]: https://github.com/clasp-lang/veriform/pull/62
[#61]: https://github.com/clasp-lang/veriform/pull/61