### PR TITLE
veriform.rs: return error when decoding out-of-order fields

### DIFF
--- a/veriform.rs/src/error.rs
+++ b/veriform.rs/src/error.rs
@@ -1,5 +1,6 @@
 //! Error type
 
+use crate::field::Tag;
 use core::fmt::{self, Display};
 
 /// Error type
@@ -14,18 +15,25 @@ pub enum Error {
     /// Length is incorrect/insufficient
     Length,
 
+    /// Field is out-of-order
+    Order {
+        /// Tag of the out-of-order field
+        tag: Tag,
+    },
+
     /// Invalid wire type
     WireType,
 }
 
 impl Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.write_str(match self {
-            Error::Decode => "decode error",
-            Error::Failed => "operation failed",
-            Error::Length => "bad length",
-            Error::WireType => "invalid wire type",
-        })
+        match self {
+            Error::Decode => write!(f, "decode error"),
+            Error::Failed => write!(f, "operation failed"),
+            Error::Length => write!(f, "bad length"),
+            Error::Order { tag } => write!(f, "out-of-order field: {}", tag),
+            Error::WireType => write!(f, "invalid wire type"),
+        }
     }
 }
 


### PR DESCRIPTION
Ensure a canonical field ordering for all messages