### PR TITLE
veriform.rs: unify length-delimited value handling

### DIFF
--- a/veriform.rs/src/field.rs
+++ b/veriform.rs/src/field.rs
@@ -53,6 +53,16 @@ pub enum WireType {
     Bytes = 3,
 }
 
+impl WireType {
+    /// Is this a wiretype which is followed by a length delimiter?
+    pub fn is_length_delimited(self) -> bool {
+        match self {
+            WireType::Message | WireType::Bytes => true,
+            _ => false,
+        }
+    }
+}
+
 impl TryFrom<u64> for WireType {
     type Error = Error;
 


### PR DESCRIPTION
Unifies the `decoder::Event` types used for handling length-delimited values so the logic isn't split between them.

Should make it easier to add more in the future (e.g. strings).