### PR TITLE
rust: add support for WireType::String

### DIFF
--- a/rust/src/error.rs
+++ b/rust/src/error.rs
@@ -21,6 +21,12 @@ pub enum Error {
         tag: Tag,
     },
 
+    /// String is not valid UTF-8
+    Utf8 {
+        /// Byte at which UTF-8 encoding failed
+        valid_up_to: usize,
+    },
+
     /// Invalid wire type
     WireType,
 }
@@ -32,6 +38,7 @@ impl Display for Error {
             Error::Failed => write!(f, "operation failed"),
             Error::Length => write!(f, "bad length"),
             Error::Order { tag } => write!(f, "out-of-order field: {}", tag),
+            Error::Utf8 { valid_up_to } => write!(f, "malformed UTF-8 at byte: {}", valid_up_to),
             Error::WireType => write!(f, "invalid wire type"),
         }
     }

--- a/rust/src/field.rs
+++ b/rust/src/field.rs
@@ -30,7 +30,7 @@ impl TryFrom<u64> for Header {
     type Error = Error;
 
     fn try_from(encoded: u64) -> Result<Self, Error> {
-        let wire_type = WireType::try_from(encoded & 0b11)?;
+        let wire_type = WireType::try_from(encoded & 0b111)?;
         let tag = encoded >> 3;
         Ok(Header { tag, wire_type })
     }
@@ -51,13 +51,16 @@ pub enum WireType {
 
     /// Binary data
     Bytes = 3,
+
+    /// Unicode string
+    String = 4,
 }
 
 impl WireType {
     /// Is this a wiretype which is followed by a length delimiter?
     pub fn is_length_delimited(self) -> bool {
         match self {
-            WireType::Message | WireType::Bytes => true,
+            WireType::Message | WireType::Bytes | WireType::String => true,
             _ => false,
         }
     }
@@ -72,6 +75,7 @@ impl TryFrom<u64> for WireType {
             1 => Ok(WireType::SInt64),
             2 => Ok(WireType::Message),
             3 => Ok(WireType::Bytes),
+            4 => Ok(WireType::String),
             _ => Err(Error::WireType),
         }
     }

--- a/spec/draft-veriform-spec.md
+++ b/spec/draft-veriform-spec.md
@@ -5,7 +5,7 @@
     category = "info"
     docName = "draft-veriform-spec"
 
-    date = 2017-11-11
+    date = 2020-02-15
 
     [[author]]
     initials = "T. "
@@ -26,20 +26,14 @@ Merkle trees.
 
 # Introduction
 
-Veriform was originally designed to provide the serializion format for a
-credential scheme (zcreds)  and as such makes many decisions aimed at
-maximizing the format's security properties, as opposed to being a general
-purpose serialization format.
+Veriform is aimed at maximizing the format's security properties, as opposed
+to being a flexible data warehousing format like Protobufs.
 
-One such decision is reducing the types which can be expressed by the format.
-In Veriform, some common types such as floats and signed integers are omitted.
-This keeps the format simple and parsimonious for security use cases.
-
-Veriform supports five scalar types:
+It supports five scalar types:
 
 * Unicode Strings (always encoded as UTF-8)
 * Binary Data
-* Integers (unsigned only)
+* Integers (signed/unsigned)
 * Timestamps
 * Booleans
 
@@ -118,16 +112,16 @@ value, so the entire integer is encoded as follows:
 
 The following wire types are supported by Veriform:
 
-| ID | Type                    | Encoding        |
-|----|-------------------------|-----------------|
-| 0  | Unsigned 64-bit Integer | vint64          |
-| 1  | Reserved                | N/A             |
-| 2  | Nested Message          | Length Prefixed |
-| 3  | Binary Data             | Length Prefixed |
-| 4  | Reserved                | N/A             |
-| 5  | Reserved                | N/A             |
-| 6  | Reserved                | N/A             |
-| 7  | Reserved                | N/A             |
+| ID | Type                    | Encoding              |
+|----|-------------------------|-----------------------|
+| 0  | Unsigned 64-bit integer | vint64                |
+| 1  | Signed 64-bit integer   | vint64 (zigzag)       |
+| 2  | Nested Message          | Length Prefixed       |
+| 3  | Binary Data             | Length Prefixed       |
+| 4  | Unicode String          | Length Prefixed UTF-8 |
+| 5  | Reserved                | N/A                   |
+| 6  | Reserved                | N/A                   |
+| 7  | Reserved                | N/A                   |
 
 The "Length Prefixed" encoding consists of a single vint64 which indicates
 the number of bytes in the subsequent value, followed by the value.


### PR DESCRIPTION
Support UTF-8 encoded strings as inputs