### PR TITLE
rust: WireType::Sequence decoder + refactoring

### DIFF
--- a/rust/src/decoder/body.rs
+++ b/rust/src/decoder/body.rs
@@ -1,0 +1,60 @@
+/// Decoder for the bodies of variable-length field values
+use super::{Event, State};
+use crate::{error::Error, field::WireType};
+
+/// Decoder for the bodies of variable-length field values
+#[derive(Debug)]
+pub(super) struct Decoder {
+    /// Wire type we're decoding
+    wire_type: WireType,
+
+    /// Remaining bytes in this field body
+    remaining: usize,
+}
+
+impl Decoder {
+    /// Create a new field value body decoder for the given wire type.
+    ///
+    /// Panics if the given wire type isn't a length-delimited type (debug-only).
+    pub fn new(wire_type: WireType, length: usize) -> Self {
+        debug_assert!(wire_type.is_length_delimited());
+
+        Self {
+            wire_type,
+            remaining: length,
+        }
+    }
+
+    /// Process the given input data, advancing the slice for the amount of
+    /// data processed, and returning the new state.
+    pub fn decode<'a>(self, input: &mut &'a [u8]) -> Result<(State, Option<Event<'a>>), Error> {
+        if input.is_empty() {
+            return Ok((self.into(), None));
+        }
+
+        let chunk_size = if input.len() >= self.remaining {
+            self.remaining
+        } else {
+            input.len()
+        };
+
+        let bytes = &input[..chunk_size];
+        *input = &input[chunk_size..];
+
+        let remaining = self.remaining.checked_sub(chunk_size).unwrap();
+        let event = Event::ValueChunk {
+            wire_type: self.wire_type,
+            bytes,
+            remaining,
+        };
+
+        let new_state = State::transition(&event);
+        Ok((new_state, Some(event)))
+    }
+}
+
+impl From<Decoder> for State {
+    fn from(decoder: Decoder) -> State {
+        State::Body(decoder)
+    }
+}

--- a/rust/src/decoder/event.rs
+++ b/rust/src/decoder/event.rs
@@ -1,0 +1,49 @@
+//! Events emitted by Veriform's decoder
+
+use crate::field::{Header, WireType};
+
+/// Events emitted by Veriform's decoder
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum Event<'a> {
+    /// Consumed field header with the given tag and wire type
+    FieldHeader(Header),
+
+    /// Consumed a boolean value
+    Bool(bool),
+
+    /// Consumed an unsigned 64-bit integer
+    UInt64(u64),
+
+    /// Consumed a signed 64-bit integer
+    SInt64(i64),
+
+    /// Consumed a length delimiter for the given wire type
+    LengthDelimiter {
+        /// Wire type of the value this length delimits
+        wire_type: WireType,
+
+        /// Length of the field body (sans delimiter)
+        length: usize,
+    },
+
+    /// Consumed a chunk of a length-delimited value
+    ValueChunk {
+        /// Wire type of the value being consumed
+        wire_type: WireType,
+
+        /// Bytes in this chunk
+        bytes: &'a [u8],
+
+        /// Remaining bytes in the message
+        remaining: usize,
+    },
+
+    /// Consumed the header of a sequence of the given wiretype
+    SequenceHeader {
+        /// Wire type contained in this sequence
+        wire_type: WireType,
+
+        /// Length of the sequence body
+        length: usize,
+    },
+}

--- a/rust/src/decoder/header.rs
+++ b/rust/src/decoder/header.rs
@@ -1,0 +1,36 @@
+//! Decoder for field headers
+
+use super::{vint64, Event, State, Tag};
+use crate::{error::Error, field::Header};
+use core::convert::TryFrom;
+
+/// Decoder for field headers
+#[derive(Default, Debug)]
+pub(super) struct Decoder(vint64::Decoder);
+
+impl Decoder {
+    /// Process the given input data, advancing the slice for the amount of
+    /// data processed, and returning the new state.
+    pub fn decode<'a>(
+        mut self,
+        input: &mut &'a [u8],
+        last_tag: Option<Tag>,
+    ) -> Result<(State, Option<Event<'a>>), Error> {
+        if let Some(value) = self.0.decode(input)? {
+            let header = Header::try_from(value)?;
+
+            // Ensure field ordering is monotonically increasing
+            if let Some(tag) = last_tag {
+                if header.tag <= tag {
+                    return Err(Error::Order { tag: header.tag });
+                }
+            }
+
+            let event = Event::FieldHeader(header);
+            let new_state = State::transition(&event);
+            Ok((new_state, Some(event)))
+        } else {
+            Ok((State::Header(self), None))
+        }
+    }
+}

--- a/rust/src/decoder/sequence.rs
+++ b/rust/src/decoder/sequence.rs
@@ -1,0 +1,160 @@
+//! Sequence decoder
+
+use super::{vint64, Event};
+use crate::{error::Error, field::WireType};
+
+/// Sequence decoder
+pub struct Decoder {
+    /// Wire type contained in this sequence
+    wire_type: WireType,
+
+    /// Remaining length in the sequence body
+    remaining: usize,
+
+    /// Current decoding state
+    state: State,
+}
+
+impl Decoder {
+    /// Create a new sequence decoder for the given wire type
+    pub fn new(wire_type: WireType, length: usize) -> Self {
+        Decoder {
+            wire_type,
+            remaining: length,
+            state: State::Value(vint64::Decoder::new()),
+        }
+    }
+
+    /// Decode a sequence from the given input
+    pub fn decode<'a>(&mut self, input: &mut &'a [u8]) -> Result<Option<Event<'a>>, Error> {
+        let event = match &mut self.state {
+            State::Value(decoder) => {
+                if let Some(value) = decoder.decode(input)? {
+                    match self.wire_type {
+                        WireType::UInt64 => Event::UInt64(value),
+                        WireType::SInt64 => Event::SInt64(vint64::decode_zigzag(value)),
+                        WireType::Sequence => Event::SequenceHeader {
+                            wire_type: WireType::from_unmasked(value)?,
+                            length: (value >> 3) as usize,
+                        },
+                        WireType::False | WireType::True => {
+                            // TODO(tarcieri): support boolean sequences?
+                            return Err(Error::Decode);
+                        }
+                        wire_type => {
+                            debug_assert!(wire_type.is_length_delimited());
+                            Event::LengthDelimiter {
+                                wire_type,
+                                length: value as usize,
+                            }
+                        }
+                    }
+                } else {
+                    return Ok(None);
+                }
+            }
+            State::Body {
+                wire_type,
+                remaining,
+            } => {
+                if input.is_empty() {
+                    return Ok(None);
+                }
+
+                let chunk_size = if input.len() >= *remaining {
+                    *remaining
+                } else {
+                    input.len()
+                };
+
+                let bytes = &input[..chunk_size];
+                *input = &input[chunk_size..];
+
+                let remaining = self.remaining.checked_sub(chunk_size).unwrap();
+
+                Event::ValueChunk {
+                    wire_type: *wire_type,
+                    bytes,
+                    remaining,
+                }
+            }
+        };
+
+        self.state = match &event {
+            Event::LengthDelimiter { wire_type, length }
+            | Event::SequenceHeader { wire_type, length } => State::Body {
+                wire_type: *wire_type,
+                remaining: *length,
+            },
+            Event::UInt64(_) | Event::SInt64(_) => State::Value(vint64::Decoder::new()),
+            Event::ValueChunk {
+                wire_type,
+                remaining,
+                ..
+            } => State::Body {
+                wire_type: *wire_type,
+                remaining: *remaining,
+            },
+            other => unreachable!("unexpected event: {:?}", other),
+        };
+
+        Ok(Some(event))
+    }
+
+    /// Decode an expected `message` field, returning an error for anything else
+    pub fn decode_message<'a>(&mut self, input: &mut &'a [u8]) -> Result<&'a [u8], Error> {
+        self.decode_value(input, WireType::Message)
+    }
+
+    /// Decode a length delimited value
+    fn decode_value<'a>(
+        &mut self,
+        input: &mut &'a [u8],
+        expected_type: WireType,
+    ) -> Result<&'a [u8], Error> {
+        if expected_type != self.wire_type {
+            return Err(Error::WireType);
+        }
+
+        let length = self.decode_length_delimiter(input)?;
+
+        if let Some(Event::ValueChunk {
+            bytes, remaining, ..
+        }) = self.decode(input)?
+        {
+            if remaining == 0 {
+                debug_assert_eq!(length, bytes.len());
+                return Ok(bytes);
+            }
+        }
+
+        Err(Error::Decode)
+    }
+
+    /// Decode a length delimiter
+    fn decode_length_delimiter(&mut self, input: &mut &[u8]) -> Result<usize, Error> {
+        debug_assert!(self.wire_type.is_length_delimited());
+
+        if let Some(Event::LengthDelimiter { length, .. }) = self.decode(input)? {
+            Ok(length)
+        } else {
+            Err(Error::Decode)
+        }
+    }
+}
+
+/// Decoder state machine
+#[derive(Debug)]
+pub(super) enum State {
+    /// Reading a `vint64` value (either value itself or length prefix)
+    Value(vint64::Decoder),
+
+    /// Reading the body of a variable-length value in a sequence
+    Body {
+        /// Wire type of the value body
+        wire_type: WireType,
+
+        /// Remaining data in the value
+        remaining: usize,
+    },
+}

--- a/rust/src/decoder/state.rs
+++ b/rust/src/decoder/state.rs
@@ -1,0 +1,81 @@
+//! Decoder state machine
+
+use super::{body, header, value, Event};
+use crate::{
+    error::Error,
+    field::{Tag, WireType},
+};
+
+/// Decoder state machine
+#[derive(Debug)]
+pub(super) enum State {
+    /// Reading the initial `vint64` header on a field
+    Header(header::Decoder),
+
+    /// Reading the `vint64` value of a field (either value itself or length prefix)
+    Value(value::Decoder),
+
+    /// Reading the body of a variable-length field
+    Body(body::Decoder),
+}
+
+impl State {
+    /// Process the given input data, advancing the slice for the amount of
+    /// data processed, and returning the new state.
+    pub(super) fn decode<'a>(
+        self,
+        input: &mut &'a [u8],
+        last_tag: Option<Tag>,
+    ) -> Result<(Self, Option<Event<'a>>), Error> {
+        match self {
+            State::Header(header) => header.decode(input, last_tag),
+            State::Value(value) => value.decode(input),
+            State::Body(body) => body.decode(input),
+        }
+    }
+
+    /// Get the new state to transition to based on a given event
+    pub(super) fn transition(event: &Event<'_>) -> Self {
+        match event {
+            Event::FieldHeader(header) => value::Decoder::new(header.wire_type).into(),
+            Event::Bool(_) | Event::UInt64(_) | Event::SInt64(_) => State::default(),
+            Event::LengthDelimiter { wire_type, length } => {
+                if *length > 0 {
+                    body::Decoder::new(*wire_type, *length).into()
+                } else {
+                    State::default()
+                }
+            }
+            Event::SequenceHeader { length, .. } => {
+                if *length > 0 {
+                    body::Decoder::new(WireType::Sequence, *length).into()
+                } else {
+                    State::default()
+                }
+            }
+            Event::ValueChunk {
+                wire_type,
+                remaining,
+                ..
+            } => {
+                if *remaining > 0 {
+                    body::Decoder::new(*wire_type, *remaining).into()
+                } else {
+                    State::default()
+                }
+            }
+        }
+    }
+}
+
+impl Default for State {
+    fn default() -> State {
+        State::Header(Default::default())
+    }
+}
+
+impl From<value::Decoder> for State {
+    fn from(decoder: value::Decoder) -> State {
+        State::Value(decoder)
+    }
+}

--- a/rust/src/decoder/value.rs
+++ b/rust/src/decoder/value.rs
@@ -1,0 +1,53 @@
+//! Decoder for field values
+
+use super::{vint64, Event, State};
+use crate::{error::Error, field::WireType};
+
+/// Decoder for field values
+#[derive(Debug)]
+pub(super) struct Decoder {
+    /// Create a new decoder for the `vint64` length prefix or value
+    decoder: vint64::Decoder,
+
+    /// Wire type we're decoding
+    wire_type: WireType,
+}
+
+impl Decoder {
+    /// Create a new value decoder for the given wire type
+    pub fn new(wire_type: WireType) -> Self {
+        Self {
+            decoder: vint64::Decoder::new(),
+            wire_type,
+        }
+    }
+
+    /// Process the given input data, advancing the slice for the amount of
+    /// data processed, and returning the new state.
+    pub fn decode<'a>(mut self, input: &mut &'a [u8]) -> Result<(State, Option<Event<'a>>), Error> {
+        if let Some(value) = self.decoder.decode(input)? {
+            let event = match self.wire_type {
+                WireType::False => Event::Bool(false),
+                WireType::True => Event::Bool(true),
+                WireType::UInt64 => Event::UInt64(value),
+                WireType::SInt64 => Event::SInt64(vint64::decode_zigzag(value)),
+                WireType::Sequence => Event::SequenceHeader {
+                    wire_type: WireType::from_unmasked(value)?,
+                    length: (value >> 3) as usize,
+                },
+                wire_type => {
+                    debug_assert!(wire_type.is_length_delimited());
+                    Event::LengthDelimiter {
+                        wire_type,
+                        length: value as usize,
+                    }
+                }
+            };
+
+            let new_state = State::transition(&event);
+            Ok((new_state, Some(event)))
+        } else {
+            Ok((State::Value(self), None))
+        }
+    }
+}

--- a/rust/src/decoder/vint64.rs
+++ b/rust/src/decoder/vint64.rs
@@ -1,0 +1,68 @@
+//! Decoder for `vint64` values
+
+pub(crate) use vint64::decode_zigzag;
+
+use crate::error::Error;
+
+/// Decoder for `vint64` values
+#[derive(Clone, Debug, Default)]
+pub struct Decoder {
+    /// Length of the field header `vint64` (if known)
+    length: Option<usize>,
+
+    /// Position we are at reading in the input buffer
+    pos: usize,
+
+    /// Incoming data buffer
+    buffer: [u8; 9],
+}
+
+impl Decoder {
+    /// Create a new [`Decoder`]
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Decode a `vint64` from the incoming data
+    pub fn decode(&mut self, input: &mut &[u8]) -> Result<Option<u64>, Error> {
+        if let Some(length) = self.length {
+            self.fill_buffer(length, input);
+            return self.maybe_decode(length);
+        }
+
+        if let Some(&hint) = input.first() {
+            self.length = Some(vint64::length_hint(hint));
+            self.decode(input)
+        } else {
+            Ok(None)
+        }
+    }
+
+    /// Fill the internal buffer with data, returning a [`FieldHeader`] if we're complete
+    fn fill_buffer(&mut self, length: usize, input: &mut &[u8]) {
+        let remaining = length.checked_sub(self.pos).unwrap();
+
+        if input.len() < remaining {
+            let new_pos = self.pos.checked_add(input.len()).unwrap();
+            self.buffer[self.pos..new_pos].copy_from_slice(*input);
+            self.pos = new_pos;
+            *input = &[];
+        } else {
+            self.buffer[self.pos..length].copy_from_slice(&input[..remaining]);
+            self.pos += remaining;
+            *input = &input[remaining..];
+        }
+    }
+
+    /// Attempt to decode the internal buffer if we've read its full contents
+    fn maybe_decode(&self, length: usize) -> Result<Option<u64>, Error> {
+        if self.pos < length {
+            return Ok(None);
+        }
+
+        let mut buffer = &self.buffer[..length];
+        vint64::decode(&mut buffer)
+            .map(Some)
+            .map_err(|_| Error::Decode)
+    }
+}

--- a/rust/src/encoder.rs
+++ b/rust/src/encoder.rs
@@ -52,14 +52,14 @@ impl<'a> Encoder<'a> {
         Ok(())
     }
 
-    /// Write a vector of messages (nested inside of a field)
+    /// Write a sequence of messages (nested inside of a field)
     pub fn message_vec<'m>(
         &mut self,
         tag: Tag,
         length: usize,
         messages: impl Iterator<Item = &'m dyn Message>,
     ) -> Result<(), Error> {
-        self.write_header(tag, WireType::Vector)?;
+        self.write_header(tag, WireType::Sequence)?;
         self.write(vint64::encode(
             (length as u64) << 3 | WireType::Message as u64,
         ))?;

--- a/rust/src/field.rs
+++ b/rust/src/field.rs
@@ -1,94 +1,10 @@
 //! Fields (i.e. key/value pair) in a message
 
+mod header;
 pub mod length;
+mod wire_type;
 
-use crate::Error;
-use core::convert::TryFrom;
-use vint64::VInt64;
+pub use self::{header::Header, wire_type::WireType};
 
 /// Tag which identifies a field
 pub type Tag = u64;
-
-/// Field headers
-#[derive(Copy, Clone, Debug, Eq, PartialEq)]
-pub struct Header {
-    /// Tag which identifies the field
-    pub tag: Tag,
-
-    /// Encoded value type for the field
-    pub wire_type: WireType,
-}
-
-impl Header {
-    /// Encode this header value as a `Vint64`
-    pub fn encode(self) -> VInt64 {
-        vint64::encode(self.tag << 3 | self.wire_type as u64)
-    }
-}
-
-impl TryFrom<u64> for Header {
-    type Error = Error;
-
-    fn try_from(encoded: u64) -> Result<Self, Error> {
-        let wire_type = WireType::try_from(encoded & 0b111)?;
-        let tag = encoded >> 3;
-        Ok(Header { tag, wire_type })
-    }
-}
-
-/// Wire type identifiers for Veriform types
-#[derive(Copy, Clone, Debug, Eq, PartialEq, PartialOrd, Ord)]
-#[repr(u64)]
-pub enum WireType {
-    /// False (boolean)
-    False = 0,
-
-    /// True (boolean)
-    True = 1,
-
-    /// 64-bit unsigned integer
-    UInt64 = 2,
-
-    /// 64-bit (zigzag) signed integer
-    SInt64 = 3,
-
-    /// Nested Veriform message
-    Message = 4,
-
-    /// Binary data
-    Bytes = 5,
-
-    /// Unicode string
-    String = 6,
-
-    /// Vectors
-    Vector = 7,
-}
-
-impl WireType {
-    /// Is this a wiretype which is followed by a length delimiter?
-    pub fn is_length_delimited(self) -> bool {
-        match self {
-            WireType::Message | WireType::Bytes | WireType::String => true,
-            _ => false,
-        }
-    }
-}
-
-impl TryFrom<u64> for WireType {
-    type Error = Error;
-
-    fn try_from(encoded: u64) -> Result<Self, Error> {
-        match encoded {
-            0 => Ok(WireType::False),
-            1 => Ok(WireType::True),
-            2 => Ok(WireType::UInt64),
-            3 => Ok(WireType::SInt64),
-            4 => Ok(WireType::Message),
-            5 => Ok(WireType::Bytes),
-            6 => Ok(WireType::String),
-            7 => Ok(WireType::Vector),
-            _ => Err(Error::WireType),
-        }
-    }
-}

--- a/rust/src/field/header.rs
+++ b/rust/src/field/header.rs
@@ -1,0 +1,33 @@
+//! Field headers
+
+use super::{Tag, WireType};
+use crate::error::Error;
+use core::convert::TryFrom;
+use vint64::VInt64;
+
+/// Field headers
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+pub struct Header {
+    /// Tag which identifies the field
+    pub tag: Tag,
+
+    /// Encoded value type for the field
+    pub wire_type: WireType,
+}
+
+impl Header {
+    /// Encode this header value as a `Vint64`
+    pub fn encode(self) -> VInt64 {
+        vint64::encode(self.tag << 3 | self.wire_type as u64)
+    }
+}
+
+impl TryFrom<u64> for Header {
+    type Error = Error;
+
+    fn try_from(encoded: u64) -> Result<Self, Error> {
+        let wire_type = WireType::try_from(encoded & 0b111)?;
+        let tag = encoded >> 3;
+        Ok(Header { tag, wire_type })
+    }
+}

--- a/rust/src/field/length.rs
+++ b/rust/src/field/length.rs
@@ -24,10 +24,10 @@ pub fn message(tag: Tag, message: &dyn Message) -> usize {
     length_delimited(tag, WireType::Message, message.encoded_len())
 }
 
-/// Compute length of a `vector` of `message` values including the tag and delimiter
+/// Compute length of a `sequence` of `message` values including the tag and delimiter
 pub fn message_vec<'a>(tag: Tag, messages: impl Iterator<Item = &'a dyn Message>) -> usize {
     let body_len: usize = messages.map(|msg| msg.encoded_len()).sum();
-    header(tag, WireType::Vector)
+    header(tag, WireType::Sequence)
         + VInt64::from((body_len as u64) << 3 | WireType::Message as u64).len()
         + body_len
 }

--- a/rust/src/field/wire_type.rs
+++ b/rust/src/field/wire_type.rs
@@ -1,0 +1,66 @@
+//! Veriform wire types
+
+pub use crate::error::Error;
+use core::convert::TryFrom;
+
+/// Wire type identifiers for Veriform types
+#[derive(Copy, Clone, Debug, Eq, PartialEq, PartialOrd, Ord)]
+#[repr(u64)]
+pub enum WireType {
+    /// False (boolean)
+    False = 0,
+
+    /// True (boolean)
+    True = 1,
+
+    /// 64-bit unsigned integer
+    UInt64 = 2,
+
+    /// 64-bit (zigzag) signed integer
+    SInt64 = 3,
+
+    /// Nested Veriform message
+    Message = 4,
+
+    /// Binary data
+    Bytes = 5,
+
+    /// Unicode string
+    String = 6,
+
+    /// Sequences
+    Sequence = 7,
+}
+
+impl WireType {
+    /// Decode a [`WireType`] from an unmasked u64
+    pub fn from_unmasked(value: u64) -> Result<Self, Error> {
+        Self::try_from(value & 0b111)
+    }
+
+    /// Is this a wiretype which is followed by a length delimiter?
+    pub fn is_length_delimited(self) -> bool {
+        match self {
+            WireType::Message | WireType::Bytes | WireType::String => true,
+            _ => false,
+        }
+    }
+}
+
+impl TryFrom<u64> for WireType {
+    type Error = Error;
+
+    fn try_from(encoded: u64) -> Result<Self, Error> {
+        match encoded {
+            0 => Ok(WireType::False),
+            1 => Ok(WireType::True),
+            2 => Ok(WireType::UInt64),
+            3 => Ok(WireType::SInt64),
+            4 => Ok(WireType::Message),
+            5 => Ok(WireType::Bytes),
+            6 => Ok(WireType::String),
+            7 => Ok(WireType::Sequence),
+            _ => Err(Error::WireType),
+        }
+    }
+}

--- a/rust/src/message.rs
+++ b/rust/src/message.rs
@@ -24,7 +24,7 @@ pub trait Message {
     /// Get the length of a message after being encoded as Veriform.
     fn encoded_len(&self) -> usize;
 
-    /// Encode this message as Veriform, returning a byte vector on success.
+    /// Encode this message as Veriform, returning a byte sequence on success.
     #[cfg(feature = "alloc")]
     fn encode_vec(&self) -> Result<Vec<u8>, Error> {
         let mut encoded = vec![0; self.encoded_len()];

--- a/rust/vint64/src/lib.rs
+++ b/rust/vint64/src/lib.rs
@@ -146,8 +146,7 @@ impl From<u64> for VInt64 {
 
 impl From<i64> for VInt64 {
     fn from(value: i64) -> VInt64 {
-        // Zigzag encoding
-        (((value << 1) ^ (value >> 63)) as u64).into()
+        encode_zigzag(value).into()
     }
 }
 
@@ -221,8 +220,17 @@ pub fn encode_signed(value: i64) -> VInt64 {
 
 /// Decode a zigzag-encoded `vint64` as a signed integer
 pub fn decode_signed(input: &mut &[u8]) -> Result<i64, Error> {
-    let decoded = decode(input)?;
-    Ok((decoded >> 1) as i64 ^ -((decoded & 1) as i64))
+    decode(input).map(decode_zigzag)
+}
+
+/// Encode a signed 64-bit integer in zigzag encoding
+pub fn encode_zigzag(value: i64) -> u64 {
+    ((value << 1) ^ (value >> 63)) as u64
+}
+
+/// Decode a signed 64-bit integer from zigzag encoding
+pub fn decode_zigzag(encoded: u64) -> i64 {
+    (encoded >> 1) as i64 ^ -((encoded & 1) as i64)
 }
 
 #[cfg(test)]

--- a/spec/draft-veriform-spec.md
+++ b/spec/draft-veriform-spec.md
@@ -40,7 +40,7 @@ It supports five scalar types:
 It supports two non-scalar types:
 
 - Objects
-- Vectors
+- Sequences
 
 ## Conventions Used in This Document
 
@@ -121,7 +121,7 @@ The following wire types are supported by Veriform:
 | 4    | message (nested)        | length prefixed        |
 | 5    | bytes                   | length prefixed        |
 | 6    | string (unicode)        | length prefixed UTF-8  |
-| 7    | vector                  | length + type prefixed |
+| 7    | sequence                | length + type prefixed |
 
 The "length prefixed" encoding consists of a single vint64 which indicates
 the number of bytes in the subsequent value, followed by the value.


### PR DESCRIPTION
Adds initial support for decoding sequences, using a simple state machine parser similar to the message parser.

This commit also includes a large amount of refactoring to split apart the decoder into separate modules for each type.