### PR TITLE
Revamp wire type ordering and field ID offsets

### DIFF
--- a/rust/src/decoder.rs
+++ b/rust/src/decoder.rs
@@ -194,7 +194,7 @@ mod tests {
 
     #[test]
     fn decode_false() {
-        let input = [66, 5];
+        let input = [130, 10];
         let mut input_ref = &input[..];
         let mut decoder = Decoder::new();
 
@@ -205,7 +205,7 @@ mod tests {
 
     #[test]
     fn decode_true() {
-        let input = [102, 5];
+        let input = [198, 10];
         let mut input_ref = &input[..];
         let mut decoder = Decoder::new();
 
@@ -216,7 +216,7 @@ mod tests {
 
     #[test]
     fn decode_uint64() {
-        let input = [74, 5, 85];
+        let input = [138, 10, 85];
         let mut input_ref = &input[..];
         let mut decoder = Decoder::new();
 
@@ -231,7 +231,7 @@ mod tests {
 
     #[test]
     fn decode_sint64() {
-        let input = [110, 5, 167];
+        let input = [206, 10, 167];
         let mut input_ref = &input[..];
         let mut decoder = Decoder::new();
 
@@ -245,23 +245,8 @@ mod tests {
     }
 
     #[test]
-    fn decode_message() {
-        let input = [25, 5, 69, 7];
-        let mut input_ref = &input[..];
-        let mut decoder = Decoder::new();
-
-        let header = decoder.decode_header(&mut input_ref).unwrap();
-        assert_eq!(header.tag, 1);
-        assert_eq!(header.wire_type, WireType::Message);
-
-        let message = decoder.decode_message(&mut input_ref).unwrap();
-        assert_eq!(message, &[69, 7]);
-        assert!(input_ref.is_empty());
-    }
-
-    #[test]
     fn decode_bytes() {
-        let input = [43, 11, 98, 121, 116, 101, 115];
+        let input = [73, 11, 98, 121, 116, 101, 115];
         let mut input_ref = &input[..];
         let mut decoder = Decoder::new();
 
@@ -276,7 +261,7 @@ mod tests {
 
     #[test]
     fn decode_string() {
-        let input = [77, 7, 98, 97, 122];
+        let input = [139, 7, 98, 97, 122];
         let mut input_ref = &input[..];
         let mut decoder = Decoder::new();
 
@@ -290,8 +275,23 @@ mod tests {
     }
 
     #[test]
+    fn decode_message() {
+        let input = [45, 5, 69, 7];
+        let mut input_ref = &input[..];
+        let mut decoder = Decoder::new();
+
+        let header = decoder.decode_header(&mut input_ref).unwrap();
+        assert_eq!(header.tag, 1);
+        assert_eq!(header.wire_type, WireType::Message);
+
+        let message = decoder.decode_message(&mut input_ref).unwrap();
+        assert_eq!(message, &[69, 7]);
+        assert!(input_ref.is_empty());
+    }
+
+    #[test]
     fn decode_multiple() {
-        let input = [74, 5, 85, 110, 5, 167];
+        let input = [138, 10, 85, 206, 10, 167];
         let mut input_ref = &input[..];
         let mut decoder = Decoder::new();
 
@@ -313,7 +313,7 @@ mod tests {
 
     #[test]
     fn decode_partial_field_header() {
-        let input = [74, 5, 85];
+        let input = [138, 10, 85];
         let mut decoder = Decoder::new();
 
         let mut input_ref = &input[..1];
@@ -327,7 +327,7 @@ mod tests {
 
     #[test]
     fn decode_out_of_order() {
-        let input = [110, 5, 167, 74, 5, 85];
+        let input = [206, 10, 167, 138, 10, 85];
         let mut input_ref = &input[..];
         let mut decoder = Decoder::new();
 

--- a/rust/src/decoder/sequence.rs
+++ b/rust/src/decoder/sequence.rs
@@ -35,7 +35,7 @@ impl Decoder {
                         WireType::SInt64 => Event::SInt64(vint64::decode_zigzag(value)),
                         WireType::Sequence => Event::SequenceHeader {
                             wire_type: WireType::from_unmasked(value)?,
-                            length: (value >> 3) as usize,
+                            length: (value >> 4) as usize,
                         },
                         WireType::False | WireType::True => {
                             // TODO(tarcieri): support boolean sequences?

--- a/rust/src/decoder/value.rs
+++ b/rust/src/decoder/value.rs
@@ -33,7 +33,7 @@ impl Decoder {
                 WireType::SInt64 => Event::SInt64(vint64::decode_zigzag(value)),
                 WireType::Sequence => Event::SequenceHeader {
                     wire_type: WireType::from_unmasked(value)?,
-                    length: (value >> 3) as usize,
+                    length: (value >> 4) as usize,
                 },
                 wire_type => {
                     debug_assert!(wire_type.is_length_delimited());

--- a/rust/src/encoder.rs
+++ b/rust/src/encoder.rs
@@ -61,7 +61,7 @@ impl<'a> Encoder<'a> {
     ) -> Result<(), Error> {
         self.write_header(tag, WireType::Sequence)?;
         self.write(vint64::encode(
-            (length as u64) << 3 | WireType::Message as u64,
+            (length as u64) << 4 | WireType::Message as u64,
         ))?;
 
         let orig_length = self.length;

--- a/rust/src/field/header.rs
+++ b/rust/src/field/header.rs
@@ -18,7 +18,7 @@ pub struct Header {
 impl Header {
     /// Encode this header value as a `Vint64`
     pub fn encode(self) -> VInt64 {
-        vint64::encode(self.tag << 3 | self.wire_type as u64)
+        vint64::encode(self.tag << 4 | self.wire_type as u64)
     }
 }
 
@@ -26,8 +26,8 @@ impl TryFrom<u64> for Header {
     type Error = Error;
 
     fn try_from(encoded: u64) -> Result<Self, Error> {
-        let wire_type = WireType::try_from(encoded & 0b111)?;
-        let tag = encoded >> 3;
+        let wire_type = WireType::from_unmasked(encoded)?;
+        let tag = encoded >> 4;
         Ok(Header { tag, wire_type })
     }
 }

--- a/rust/src/field/length.rs
+++ b/rust/src/field/length.rs
@@ -28,7 +28,7 @@ pub fn message(tag: Tag, message: &dyn Message) -> usize {
 pub fn message_vec<'a>(tag: Tag, messages: impl Iterator<Item = &'a dyn Message>) -> usize {
     let body_len: usize = messages.map(|msg| msg.encoded_len()).sum();
     header(tag, WireType::Sequence)
-        + VInt64::from((body_len as u64) << 3 | WireType::Message as u64).len()
+        + VInt64::from((body_len as u64) << 4 | WireType::Message as u64).len()
         + body_len
 }
 

--- a/rust/src/field/wire_type.rs
+++ b/rust/src/field/wire_type.rs
@@ -19,14 +19,14 @@ pub enum WireType {
     /// 64-bit (zigzag) signed integer
     SInt64 = 3,
 
-    /// Nested Veriform message
-    Message = 4,
-
     /// Binary data
-    Bytes = 5,
+    Bytes = 4,
 
     /// Unicode string
-    String = 6,
+    String = 5,
+
+    /// Nested Veriform message
+    Message = 6,
 
     /// Sequences
     Sequence = 7,
@@ -56,9 +56,9 @@ impl TryFrom<u64> for WireType {
             1 => Ok(WireType::True),
             2 => Ok(WireType::UInt64),
             3 => Ok(WireType::SInt64),
-            4 => Ok(WireType::Message),
-            5 => Ok(WireType::Bytes),
-            6 => Ok(WireType::String),
+            4 => Ok(WireType::Bytes),
+            5 => Ok(WireType::String),
+            6 => Ok(WireType::Message),
             7 => Ok(WireType::Sequence),
             _ => Err(Error::WireType),
         }

--- a/spec/draft-veriform-spec.md
+++ b/spec/draft-veriform-spec.md
@@ -108,7 +108,9 @@ field identifier (the "key" of the key/value pair) along with a wire type
 identifier. The lower 3 bits of this initial varint contain the wire type
 value, so the entire integer is encoded as follows:
 
-    (field_number << 3) | wire_type
+    (field_number << 4) | (critical_bit << 3) | wire_type
+
+### Wire Types
 
 The following wire types are supported by Veriform:
 
@@ -118,9 +120,9 @@ The following wire types are supported by Veriform:
 | 1    | true                    | none                   |
 | 2    | unsigned 64-bit integer | vint64                 |
 | 3    | signed 64-bit integer   | vint64 (zigzag)        |
-| 4    | message (nested)        | length prefixed        |
-| 5    | bytes                   | length prefixed        |
-| 6    | string (unicode)        | length prefixed UTF-8  |
+| 4    | bytes                   | length prefixed        |
+| 5    | string (unicode)        | length prefixed UTF-8  |
+| 6    | message (nested)        | length prefixed        |
 | 7    | sequence                | length + type prefixed |
 
 The "length prefixed" encoding consists of a single vint64 which indicates


### PR DESCRIPTION
This commit moves the "message" and "sequence" wire types to the highest numbered wire type identifiers (6 and 7).

It also changes the offset for the field ID from 3-bits to 4-bits. This is to make room for a "critical bit" similar to the one used to identify critical X.509 extensions.

Implementing basic support for the critical bit will happen in a follow-up PR.