### PR TITLE
Add "critical bit" to denote critical fields

### DIFF
--- a/rust/src/field/header.rs
+++ b/rust/src/field/header.rs
@@ -11,14 +11,27 @@ pub struct Header {
     /// Tag which identifies the field
     pub tag: Tag,
 
+    /// Indicates a field containing critical information which
+    /// shouldn't be ignored if the field is unknown
+    pub critical: bool,
+
     /// Encoded value type for the field
     pub wire_type: WireType,
 }
 
 impl Header {
+    /// Create a new header
+    pub fn new(tag: Tag, critical: bool, wire_type: WireType) -> Self {
+        Header {
+            tag,
+            critical,
+            wire_type,
+        }
+    }
+
     /// Encode this header value as a `Vint64`
     pub fn encode(self) -> VInt64 {
-        vint64::encode(self.tag << 4 | self.wire_type as u64)
+        vint64::encode(self.tag << 4 | (self.critical as u64) << 3 | self.wire_type as u64)
     }
 }
 
@@ -27,7 +40,8 @@ impl TryFrom<u64> for Header {
 
     fn try_from(encoded: u64) -> Result<Self, Error> {
         let wire_type = WireType::from_unmasked(encoded)?;
+        let critical = encoded >> 3 & 1 == 1;
         let tag = encoded >> 4;
-        Ok(Header { tag, wire_type })
+        Ok(Header::new(tag, critical, wire_type))
     }
 }

--- a/rust/src/field/length.rs
+++ b/rust/src/field/length.rs
@@ -5,39 +5,43 @@ use crate::message::Message;
 use vint64::VInt64;
 
 /// Compute length of a `uint64` field
-pub fn uint64(tag: Tag, value: u64) -> usize {
-    header(tag, WireType::UInt64) + VInt64::from(value).len()
+pub fn uint64(tag: Tag, critical: bool, value: u64) -> usize {
+    header(tag, critical, WireType::UInt64) + VInt64::from(value).len()
 }
 
 /// Compute length of an `sint64` field
-pub fn sint64(tag: Tag, value: i64) -> usize {
-    header(tag, WireType::SInt64) + VInt64::from(value).len()
+pub fn sint64(tag: Tag, critical: bool, value: i64) -> usize {
+    header(tag, critical, WireType::SInt64) + VInt64::from(value).len()
 }
 
 /// Compute length of a `bytes` field
-pub fn bytes(tag: Tag, bytes: &[u8]) -> usize {
-    length_delimited(tag, WireType::Bytes, bytes.len())
+pub fn bytes(tag: Tag, critical: bool, bytes: &[u8]) -> usize {
+    length_delimited(tag, critical, WireType::Bytes, bytes.len())
 }
 
 /// Compute length of a `message` field including the tag and delimiter
-pub fn message(tag: Tag, message: &dyn Message) -> usize {
-    length_delimited(tag, WireType::Message, message.encoded_len())
+pub fn message(tag: Tag, critical: bool, message: &dyn Message) -> usize {
+    length_delimited(tag, critical, WireType::Message, message.encoded_len())
 }
 
 /// Compute length of a `sequence` of `message` values including the tag and delimiter
-pub fn message_vec<'a>(tag: Tag, messages: impl Iterator<Item = &'a dyn Message>) -> usize {
+pub fn message_vec<'a>(
+    tag: Tag,
+    critical: bool,
+    messages: impl Iterator<Item = &'a dyn Message>,
+) -> usize {
     let body_len: usize = messages.map(|msg| msg.encoded_len()).sum();
-    header(tag, WireType::Sequence)
+    header(tag, critical, WireType::Sequence)
         + VInt64::from((body_len as u64) << 4 | WireType::Message as u64).len()
         + body_len
 }
 
 /// Compute length of a field header
-fn header(tag: Tag, wire_type: WireType) -> usize {
-    Header { tag, wire_type }.encode().len()
+fn header(tag: Tag, critical: bool, wire_type: WireType) -> usize {
+    Header::new(tag, critical, wire_type).encode().len()
 }
 
 /// Compute length of a length delimited field
-fn length_delimited(tag: Tag, wire_type: WireType, length: usize) -> usize {
-    header(tag, wire_type) + VInt64::from(length as u64).len() + length
+fn length_delimited(tag: Tag, critical: bool, wire_type: WireType, length: usize) -> usize {
+    header(tag, critical, wire_type) + VInt64::from(length as u64).len() + length
 }

--- a/spec/draft-veriform-spec.md
+++ b/spec/draft-veriform-spec.md
@@ -110,6 +110,16 @@ value, so the entire integer is encoded as follows:
 
     (field_number << 4) | (critical_bit << 3) | wire_type
 
+### Critical Bit
+
+The "critical bit" is a 1-bit flag used to signal that a field is critical
+to the interpretation of the message and MUST NOT be ignored.
+
+If a message contains an unknown field with the critical bit set, it MUST
+be rejected by the parser. This applies to all fields of unknown messages
+recursively: parsers MUST process the contents of unknown messages to ensure
+that none of them contain critical fields.
+
 ### Wire Types
 
 The following wire types are supported by Veriform:


### PR DESCRIPTION
X.509 has the notion of "critical extensions": ones which can't be ignored if present but unknown/unrecognized.

This commit specs and adds a "critical bit" to all fields, which signals that a message must be rejected if a critical field is unknown.