### PR TITLE
rust: length-delimited -> dynamically-sized

### DIFF
--- a/rust/src/decoder/decodable.rs
+++ b/rust/src/decoder/decodable.rs
@@ -12,7 +12,7 @@ pub trait Decodable {
     fn decode<'a>(&mut self, input: &mut &'a [u8]) -> Result<Option<Event<'a>>, Error>;
 
     /// Decode a length delimited value, expecting the given wire type
-    fn decode_length_delimited_value<'a>(
+    fn decode_dynamically_sized_value<'a>(
         &mut self,
         input: &mut &'a [u8],
         expected_type: WireType,
@@ -36,12 +36,12 @@ pub trait Decodable {
 
     /// Decode an expected `bytes` field, returning an error for anything else
     fn decode_bytes<'a>(&mut self, input: &mut &'a [u8]) -> Result<&'a [u8], Error> {
-        self.decode_length_delimited_value(input, WireType::Bytes)
+        self.decode_dynamically_sized_value(input, WireType::Bytes)
     }
 
     /// Decode an expected `string` field, returning an error for anything else
     fn decode_string<'a>(&mut self, input: &mut &'a [u8]) -> Result<&'a str, Error> {
-        let bytes = self.decode_length_delimited_value(input, WireType::String)?;
+        let bytes = self.decode_dynamically_sized_value(input, WireType::String)?;
         str::from_utf8(bytes).map_err(|e| Error::Utf8 {
             valid_up_to: e.valid_up_to(),
         })
@@ -49,7 +49,7 @@ pub trait Decodable {
 
     /// Decode an expected `message` field, returning an error for anything else
     fn decode_message<'a>(&mut self, input: &mut &'a [u8]) -> Result<&'a [u8], Error> {
-        self.decode_length_delimited_value(input, WireType::Message)
+        self.decode_dynamically_sized_value(input, WireType::Message)
     }
 
     /// Decode an expected `sequence` field, returning an error for anything else

--- a/rust/src/decoder/event.rs
+++ b/rust/src/decoder/event.rs
@@ -26,7 +26,7 @@ pub enum Event<'a> {
         length: usize,
     },
 
-    /// Consumed a chunk of a length-delimited value
+    /// Consumed a chunk of a dynamically sized value
     ValueChunk {
         /// Wire type of the value being consumed
         wire_type: WireType,

--- a/rust/src/decoder/message.rs
+++ b/rust/src/decoder/message.rs
@@ -73,7 +73,11 @@ impl Decoder {
         input: &mut &[u8],
         expected_type: WireType,
     ) -> Result<usize, Error> {
-        debug_assert!(expected_type.is_length_delimited());
+        debug_assert!(
+            expected_type.is_dynamically_sized(),
+            "not a dynamically sized wire type: {:?}",
+            expected_type
+        );
 
         if let Some(Event::LengthDelimiter { wire_type, length }) = self.decode(input)? {
             if wire_type == expected_type {
@@ -101,7 +105,7 @@ impl Decodable for Decoder {
         }
     }
 
-    fn decode_length_delimited_value<'a>(
+    fn decode_dynamically_sized_value<'a>(
         &mut self,
         input: &mut &'a [u8],
         expected_type: WireType,

--- a/rust/src/decoder/message/body.rs
+++ b/rust/src/decoder/message/body.rs
@@ -15,11 +15,11 @@ pub(super) struct Decoder {
 impl Decoder {
     /// Create a new field value body decoder for the given wire type.
     ///
-    /// Panics if the given wire type isn't a length-delimited type (debug-only).
+    /// Panics if the given wire type isn't dynamically sized (debug-only).
     pub fn new(wire_type: WireType, length: usize) -> Self {
         debug_assert!(
-            wire_type.is_length_delimited(),
-            "not a length-delimited wire type: {:?}",
+            wire_type.is_dynamically_sized(),
+            "not a dynamically sized wire type: {:?}",
             wire_type
         );
 

--- a/rust/src/decoder/message/value.rs
+++ b/rust/src/decoder/message/value.rs
@@ -41,8 +41,8 @@ impl Decoder {
                 },
                 wire_type => {
                     debug_assert!(
-                        wire_type.is_length_delimited(),
-                        "not a length-delimited wire type: {:?}",
+                        wire_type.is_dynamically_sized(),
+                        "not a dynamically sized wire type: {:?}",
                         wire_type
                     );
 

--- a/rust/src/decoder/sequence.rs
+++ b/rust/src/decoder/sequence.rs
@@ -28,8 +28,8 @@ impl Decoder {
     /// Decode a length delimiter
     fn decode_length_delimiter(&mut self, input: &mut &[u8]) -> Result<usize, Error> {
         debug_assert!(
-            self.wire_type.is_length_delimited(),
-            "not a length-delimited wire type: {:?}",
+            self.wire_type.is_dynamically_sized(),
+            "not a dynamically sized wire type: {:?}",
             self.wire_type
         );
 
@@ -79,7 +79,7 @@ impl Decodable for Decoder {
         Ok(maybe_event)
     }
 
-    fn decode_length_delimited_value<'a>(
+    fn decode_dynamically_sized_value<'a>(
         &mut self,
         input: &mut &'a [u8],
         expected_type: WireType,
@@ -150,8 +150,8 @@ impl State {
                         }
                         wire_type => {
                             debug_assert!(
-                                wire_type.is_length_delimited(),
-                                "not a length-delimited wire type: {:?}",
+                                wire_type.is_dynamically_sized(),
+                                "not a dynamically sized wire type: {:?}",
                                 wire_type
                             );
 

--- a/rust/src/encoder.rs
+++ b/rust/src/encoder.rs
@@ -113,7 +113,7 @@ impl<'a> Encoder<'a> {
         self.write(Header::new(tag, critical, wire_type).encode())
     }
 
-    /// Write a length-delimited value to the underlying buffer
+    /// Write a dynamically sized value to the underlying buffer
     fn write_value(&mut self, bytes: &[u8]) -> Result<(), Error> {
         self.write(vint64::encode(bytes.len() as u64))?;
         self.write(bytes)

--- a/rust/src/field/length.rs
+++ b/rust/src/field/length.rs
@@ -16,12 +16,12 @@ pub fn sint64(tag: Tag, critical: bool, value: i64) -> usize {
 
 /// Compute length of a `bytes` field
 pub fn bytes(tag: Tag, critical: bool, bytes: &[u8]) -> usize {
-    length_delimited(tag, critical, WireType::Bytes, bytes.len())
+    dynamically_sized(tag, critical, WireType::Bytes, bytes.len())
 }
 
 /// Compute length of a `message` field including the tag and delimiter
 pub fn message(tag: Tag, critical: bool, message: &dyn Message) -> usize {
-    length_delimited(tag, critical, WireType::Message, message.encoded_len())
+    dynamically_sized(tag, critical, WireType::Message, message.encoded_len())
 }
 
 /// Compute length of a `sequence` of `message` values including the tag and delimiter
@@ -41,7 +41,7 @@ fn header(tag: Tag, critical: bool, wire_type: WireType) -> usize {
     Header::new(tag, critical, wire_type).encode().len()
 }
 
-/// Compute length of a length delimited field
-fn length_delimited(tag: Tag, critical: bool, wire_type: WireType, length: usize) -> usize {
+/// Compute length of a dynamically sized field
+fn dynamically_sized(tag: Tag, critical: bool, wire_type: WireType, length: usize) -> usize {
     header(tag, critical, wire_type) + VInt64::from(length as u64).len() + length
 }

--- a/rust/src/field/wire_type.rs
+++ b/rust/src/field/wire_type.rs
@@ -38,10 +38,10 @@ impl WireType {
         Self::try_from(value & 0b111)
     }
 
-    /// Is this a wiretype which is followed by a length delimiter?
-    pub fn is_length_delimited(self) -> bool {
+    /// Is this a dynamically-sized [`WireType`]?
+    pub fn is_dynamically_sized(self) -> bool {
         match self {
-            WireType::Message | WireType::Bytes | WireType::String => true,
+            WireType::Bytes | WireType::String | WireType::Message | WireType::Sequence => true,
             _ => false,
         }
     }


### PR DESCRIPTION
Renames "length delimited" in docs and the API to "dynamically sized", both because that's clearer terminology (at least to Rust developers), but also to account for sequences, which use a slightly different length delimiter (TLV-ish).