### PR TITLE
rust: use `displaydoc` for `Error` type; MSRV 1.40+

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -18,7 +18,7 @@ jobs:
           - thumbv7em-none-eabihf
           - wasm32-unknown-unknown
         toolchain:
-          - 1.39.0
+          - 1.40.0
           - stable
     steps:
       - name: Checkout sources
@@ -138,7 +138,7 @@ jobs:
           - macos-latest
           - windows-latest
         toolchain:
-          - 1.39.0
+          - 1.40.0
           - stable
     runs-on: ${{ matrix.platform }}
     steps:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -174,6 +174,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "displaydoc"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "proc-macro2 1.0.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 1.0.16 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "either"
 version = "1.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -467,6 +477,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 name = "veriform"
 version = "0.0.1"
 dependencies = [
+ "displaydoc 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "vint64 0.2.1",
 ]
 
@@ -624,6 +635,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum crossbeam-utils 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)" = "c3c7c73a2d1e9fc0886a08b93e98eb643461230d5f1925e4036204d5f2e261a8"
 "checksum csv 1.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "00affe7f6ab566df61b4be3ce8cf16bc2576bca0963ceb0955e45d514bf9a279"
 "checksum csv-core 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)" = "2b2466559f260f48ad25fe6317b3c8dac77b5bdb5763ac7d9d6103530663bc90"
+"checksum displaydoc 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "a06d4ceb0482364a62aa1e4393da51c8aa3229432e8893fe7e3da9f884c97130"
 "checksum either 1.5.3 (registry+https://github.com/rust-lang/crates.io-index)" = "bb1f6b1ce1c140482ea30ddd3335fc0024ac7ee112895426e0a629a6c20adfe3"
 "checksum heck 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "20564e78d53d2bb135c343b3f47714a56af2061f1c928fdb541dc7b9fdd94205"
 "checksum hermit-abi 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)" = "1010591b26bbfe835e9faeabeb11866061cc7dcebffd56ad7d0942d0e61aefd8"

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -12,6 +12,7 @@ categories  = ["authentication", "cryptography", "encoding"]
 keywords    = ["hashing", "merkle", "protobufs", "security", "serialization"]
 
 [dependencies]
+displaydoc = { version = "0.1", default-features = false }
 vint64 = { version = "0.2", path = "vint64" }
 
 [features]

--- a/rust/README.md
+++ b/rust/README.md
@@ -38,7 +38,7 @@ without any additional terms or conditions.
 [docs-link]: https://docs.rs/veriform/
 [license-image]: https://img.shields.io/badge/license-Apache2.0-blue.svg
 [license-link]: https://github.com/iqlusioninc/veriform/blob/develop/LICENSE
-[msrv-image]: https://img.shields.io/badge/rustc-1.39+-blue.svg
+[msrv-image]: https://img.shields.io/badge/rustc-1.40+-blue.svg
 [build-image]: https://github.com/iqlusioninc/veriform/workflows/Rust/badge.svg?branch=develop&event=push
 [build-link]: https://github.com/iqlusioninc/veriform/actions?query=workflow%3ARust
 

--- a/rust/src/error.rs
+++ b/rust/src/error.rs
@@ -1,47 +1,34 @@
 //! Error type
 
 use crate::field::Tag;
-use core::fmt::{self, Display};
+use displaydoc::Display;
 
 /// Error type
-#[derive(Clone, Debug, Eq, PartialEq)]
+#[derive(Copy, Clone, Debug, Display, Eq, PartialEq)]
 pub enum Error {
-    /// Malformed data encountered while decoding
+    /// decode error
     Decode,
 
-    /// Operation failed or is in a bad state
+    /// operation failed
     Failed,
 
-    /// Length is incorrect/insufficient
+    /// bad length
     Length,
 
-    /// Field is out-of-order
+    /// field {tag:?} is out-of-order
     Order {
-        /// Tag of the out-of-order field
+        /// tag of the out-of-order field
         tag: Tag,
     },
 
-    /// String is not valid UTF-8
+    /// malformed UTF-8 encountered at byte: {valid_up_to:?}
     Utf8 {
-        /// Byte at which UTF-8 encoding failed
+        /// byte at which UTF-8 encoding failed
         valid_up_to: usize,
     },
 
-    /// Invalid wire type
+    /// invalid wire type
     WireType,
-}
-
-impl Display for Error {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            Error::Decode => write!(f, "decode error"),
-            Error::Failed => write!(f, "operation failed"),
-            Error::Length => write!(f, "bad length"),
-            Error::Order { tag } => write!(f, "out-of-order field: {}", tag),
-            Error::Utf8 { valid_up_to } => write!(f, "malformed UTF-8 at byte: {}", valid_up_to),
-            Error::WireType => write!(f, "invalid wire type"),
-        }
-    }
 }
 
 #[cfg(feature = "std")]

--- a/rust/vint64/README.md
+++ b/rust/vint64/README.md
@@ -53,7 +53,7 @@ without any additional terms or conditions.
 [docs-link]: https://docs.rs/vint64/
 [license-image]: https://img.shields.io/badge/license-Apache2.0-blue.svg
 [license-link]: https://github.com/iqlusioninc/veriform/blob/develop/LICENSE
-[msrv-image]: https://img.shields.io/badge/rustc-1.39+-blue.svg
+[msrv-image]: https://img.shields.io/badge/rustc-1.40+-blue.svg
 [safety-image]: https://img.shields.io/badge/unsafe-forbidden-success.svg
 [safety-link]: https://github.com/rust-secure-code/safety-dance/
 [build-image]: https://github.com/iqlusioninc/veriform/workflows/Rust/badge.svg?branch=develop&event=push


### PR DESCRIPTION
`displaydoc` provides a `no_std`-friendly procedural macro for creating `Display` impls from documentation comments:

https://github.com/yaahc/displaydoc