### PR TITLE
rust: error type improvements; WireType::from impl

### DIFF
--- a/rust/src/decoder/message/header.rs
+++ b/rust/src/decoder/message/header.rs
@@ -6,7 +6,6 @@ use crate::{
     error::Error,
     field::Header,
 };
-use core::convert::TryFrom;
 
 /// Decoder for field headers
 #[derive(Default, Debug)]
@@ -21,7 +20,7 @@ impl Decoder {
         last_tag: Option<Tag>,
     ) -> Result<(State, Option<Event<'a>>), Error> {
         if let Some(value) = self.0.decode(input)? {
-            let header = Header::try_from(value)?;
+            let header = Header::from(value);
 
             // Ensure field ordering is monotonically increasing
             if let Some(tag) = last_tag {

--- a/rust/src/decoder/message/value.rs
+++ b/rust/src/decoder/message/value.rs
@@ -36,7 +36,7 @@ impl Decoder {
                 WireType::UInt64 => Event::UInt64(value),
                 WireType::SInt64 => Event::SInt64(vint64::decode_zigzag(value)),
                 WireType::Sequence => Event::SequenceHeader {
-                    wire_type: WireType::from_unmasked(value)?,
+                    wire_type: WireType::from_unmasked(value),
                     length: (value >> 4) as usize,
                 },
                 wire_type => {

--- a/rust/src/decoder/vint64.rs
+++ b/rust/src/decoder/vint64.rs
@@ -63,6 +63,6 @@ impl Decoder {
         let mut buffer = &self.buffer[..length];
         vint64::decode(&mut buffer)
             .map(Some)
-            .map_err(|_| Error::Decode)
+            .map_err(|_| Error::VInt64)
     }
 }

--- a/rust/src/error.rs
+++ b/rust/src/error.rs
@@ -1,16 +1,28 @@
 //! Error type
 
-use crate::field::Tag;
+use crate::field::{Tag, WireType};
 use displaydoc::Display;
 
 /// Error type
 #[derive(Copy, Clone, Debug, Display, Eq, PartialEq)]
 pub enum Error {
-    /// decode error
-    Decode,
+    /// decoding failed: wire_type={wire_type:?}
+    Decode {
+        /// wire type we were looking for when decoding failed
+        wire_type: WireType,
+    },
 
     /// operation failed
     Failed,
+
+    /// invalid field header: tag={tag:?} wire_type={wire_type:?}
+    FieldHeader {
+        /// tag which identifies this field
+        tag: Option<Tag>,
+
+        /// expected wire type for field
+        wire_type: Option<WireType>,
+    },
 
     /// bad length
     Length,
@@ -27,8 +39,14 @@ pub enum Error {
         valid_up_to: usize,
     },
 
-    /// invalid wire type
-    WireType,
+    /// `vint64` encoding error
+    VInt64,
+
+    /// invalid wire type: {wanted:?}
+    WireType {
+        /// wire type we were looking for
+        wanted: Option<WireType>,
+    },
 }
 
 #[cfg(feature = "std")]

--- a/rust/src/field/header.rs
+++ b/rust/src/field/header.rs
@@ -1,8 +1,6 @@
 //! Field headers
 
 use super::{Tag, WireType};
-use crate::error::Error;
-use core::convert::TryFrom;
 use vint64::VInt64;
 
 /// Field headers
@@ -35,13 +33,12 @@ impl Header {
     }
 }
 
-impl TryFrom<u64> for Header {
-    type Error = Error;
-
-    fn try_from(encoded: u64) -> Result<Self, Error> {
-        let wire_type = WireType::from_unmasked(encoded)?;
-        let critical = encoded >> 3 & 1 == 1;
-        let tag = encoded >> 4;
-        Ok(Header::new(tag, critical, wire_type))
+impl From<u64> for Header {
+    fn from(encoded: u64) -> Self {
+        Header {
+            tag: encoded >> 4,
+            critical: encoded >> 3 & 1 == 1,
+            wire_type: WireType::from_unmasked(encoded),
+        }
     }
 }

--- a/rust/src/field/wire_type.rs
+++ b/rust/src/field/wire_type.rs
@@ -34,8 +34,9 @@ pub enum WireType {
 
 impl WireType {
     /// Decode a [`WireType`] from an unmasked u64
-    pub fn from_unmasked(value: u64) -> Result<Self, Error> {
-        Self::try_from(value & 0b111)
+    pub fn from_unmasked(value: u64) -> Self {
+        // Never panics because all 3-bit wire types are valid
+        Self::try_from(value & 0b111).unwrap()
     }
 
     /// Is this a dynamically-sized [`WireType`]?
@@ -60,7 +61,7 @@ impl TryFrom<u64> for WireType {
             5 => Ok(WireType::String),
             6 => Ok(WireType::Message),
             7 => Ok(WireType::Sequence),
-            _ => Err(Error::WireType),
+            _ => Err(Error::WireType { wanted: None }),
         }
     }
 }


### PR DESCRIPTION
Adds additional decode error context and error types, which should help debug encoding issues as they arise.

Also changes `WireType::try_from` => `WireType::from`, now that all 3-bit wire type IDs are valid.