### PR TITLE
rust: include `message::Element` in `Error::Decode`

### DIFF
--- a/rust/src/decoder/decodable.rs
+++ b/rust/src/decoder/decodable.rs
@@ -2,7 +2,7 @@
 //! `message` and `sequence` decoders
 
 use super::Event;
-use crate::{error::Error, field::WireType};
+use crate::{error::Error, field::WireType, message::Element};
 use core::str;
 
 /// Common functionality between the `message` and `sequence` decoders
@@ -23,6 +23,7 @@ pub trait Decodable {
         match self.decode(input)? {
             Some(Event::UInt64(value)) => Ok(value),
             _ => Err(Error::Decode {
+                element: Element::Value,
                 wire_type: WireType::UInt64,
             }),
         }
@@ -33,6 +34,7 @@ pub trait Decodable {
         match self.decode(input)? {
             Some(Event::SInt64(value)) => Ok(value),
             _ => Err(Error::Decode {
+                element: Element::Value,
                 wire_type: WireType::SInt64,
             }),
         }
@@ -68,6 +70,7 @@ pub trait Decodable {
             }
             _ => {
                 return Err(Error::Decode {
+                    element: Element::SequenceHeader,
                     wire_type: expected_type,
                 })
             }
@@ -81,6 +84,7 @@ pub trait Decodable {
                 Ok(bytes)
             }
             _ => Err(Error::Decode {
+                element: Element::Value,
                 wire_type: expected_type,
             }),
         }

--- a/rust/src/decoder/sequence.rs
+++ b/rust/src/decoder/sequence.rs
@@ -1,7 +1,7 @@
 //! Sequence decoder
 
 use super::{vint64, Decodable, Event};
-use crate::{error::Error, field::WireType};
+use crate::{error::Error, field::WireType, message::Element};
 
 /// Sequence decoder
 pub struct Decoder {
@@ -51,6 +51,7 @@ impl Decoder {
         match self.decode(input)? {
             Some(Event::LengthDelimiter { length, .. }) => Ok(length),
             _ => Err(Error::Decode {
+                element: Element::LengthDelimiter,
                 wire_type: self.wire_type,
             }),
         }
@@ -116,6 +117,7 @@ impl Decodable for Decoder {
                 Ok(bytes)
             }
             _ => Err(Error::Decode {
+                element: Element::Value,
                 wire_type: expected_type,
             }),
         }
@@ -164,7 +166,10 @@ impl State {
                         },
                         WireType::False | WireType::True => {
                             // TODO(tarcieri): support boolean sequences?
-                            return Err(Error::Decode { wire_type });
+                            return Err(Error::Decode {
+                                element: Element::Value,
+                                wire_type,
+                            });
                         }
                         wire_type => {
                             debug_assert!(

--- a/rust/src/error.rs
+++ b/rust/src/error.rs
@@ -1,6 +1,9 @@
 //! Error type
 
-use crate::field::{Tag, WireType};
+use crate::{
+    field::{Tag, WireType},
+    message::Element,
+};
 use displaydoc::Display;
 
 /// Error type
@@ -8,6 +11,9 @@ use displaydoc::Display;
 pub enum Error {
     /// decoding failed: wire_type={wire_type:?}
     Decode {
+        /// element of the message that failed to decode
+        element: Element,
+
         /// wire type we were looking for when decoding failed
         wire_type: WireType,
     },

--- a/rust/src/message.rs
+++ b/rust/src/message.rs
@@ -10,6 +10,22 @@ use crate::Error;
 #[cfg(feature = "alloc")]
 use alloc::vec::Vec;
 
+/// Elements of a message (used for errors)
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+pub enum Element {
+    /// Length delimiters for dynamically sized fields
+    LengthDelimiter,
+
+    /// Headers of sequences
+    SequenceHeader,
+
+    /// Tags identify the types of fields
+    Tag,
+
+    /// Field values (i.e. inside the body of a field value)
+    Value,
+}
+
 /// Veriform message
 pub trait Message {
     /// Decode a Veriform message contained in the provided slice.


### PR DESCRIPTION
Should provide more context for decoding errors