### PR TITLE
rust: fix sequence decoding

### DIFF
--- a/rust/src/decoder/decodable.rs
+++ b/rust/src/decoder/decodable.rs
@@ -79,13 +79,20 @@ pub trait Decodable {
         match self.decode(input)? {
             Some(Event::ValueChunk {
                 bytes, remaining, ..
-            }) if remaining == 0 => {
-                debug_assert_eq!(length, bytes.len());
-                Ok(bytes)
+            }) => {
+                if remaining == 0 {
+                    debug_assert_eq!(length, bytes.len());
+                    Ok(bytes)
+                } else {
+                    Err(Error::Truncated {
+                        remaining,
+                        wire_type: WireType::Sequence,
+                    })
+                }
             }
             _ => Err(Error::Decode {
                 element: Element::Value,
-                wire_type: expected_type,
+                wire_type: WireType::Sequence,
             }),
         }
     }

--- a/rust/src/decoder/message.rs
+++ b/rust/src/decoder/message.rs
@@ -64,9 +64,16 @@ impl Decodable for Decoder {
                 wire_type,
                 bytes,
                 remaining,
-            }) if wire_type == expected_type && remaining == 0 => {
-                debug_assert_eq!(length, bytes.len());
-                Ok(bytes)
+            }) if wire_type == expected_type => {
+                if remaining == 0 {
+                    debug_assert_eq!(length, bytes.len());
+                    Ok(bytes)
+                } else {
+                    Err(Error::Truncated {
+                        remaining,
+                        wire_type,
+                    })
+                }
             }
             _ => Err(Error::Decode {
                 element: Element::Value,

--- a/rust/src/error.rs
+++ b/rust/src/error.rs
@@ -39,6 +39,15 @@ pub enum Error {
         tag: Tag,
     },
 
+    /// truncated message: remaining={remaining:?} wire_type={wire_type:?}
+    Truncated {
+        /// number of bytes of remaining data expected in the message
+        remaining: usize,
+
+        /// wire type of the truncated data
+        wire_type: WireType,
+    },
+
     /// malformed UTF-8 encountered at byte: {valid_up_to:?}
     Utf8 {
         /// byte at which UTF-8 encoding failed


### PR DESCRIPTION
It seems this code was broken but passed the tests because the tests were buggy (they hardcoded the wrong length).

This fixes both the code and the tests.

Right now test coverage of this section is poor and could definitely be improved, but for now this is a stop-the-bleeding fix.