### PR TITLE
rust: initial builtin types: TAI64N and UUID

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -442,6 +442,11 @@ dependencies = [
 ]
 
 [[package]]
+name = "tai64"
+version = "3.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "textwrap"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -474,10 +479,17 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "uuid"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "veriform"
 version = "0.0.1"
 dependencies = [
  "displaydoc 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tai64 3.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "uuid 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "vint64 0.2.1",
 ]
 
@@ -671,11 +683,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum serde_json 1.0.48 (registry+https://github.com/rust-lang/crates.io-index)" = "9371ade75d4c2d6cb154141b9752cf3781ec9c05e0e5cf35060e1e70ee7b9c25"
 "checksum sourcefile 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "4bf77cb82ba8453b42b6ae1d692e4cdc92f9a47beaf89a847c8be83f4e328ad3"
 "checksum syn 1.0.16 (registry+https://github.com/rust-lang/crates.io-index)" = "123bd9499cfb380418d509322d7a6d52e5315f064fe4b3ad18a53d6b92c07859"
+"checksum tai64 3.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "4014289c3d2b8168880ae86633247e73712fcc579969aff0ca7c5dcd17456b82"
 "checksum textwrap 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
 "checksum tinytemplate 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "57a3c6667d3e65eb1bc3aed6fd14011c6cbc3a0665218ab7f5daf040b9ec371a"
 "checksum unicode-segmentation 1.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e83e153d1053cbb5a118eeff7fd5be06ed99153f00dbcd8ae310c5fb2b22edc0"
 "checksum unicode-width 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)" = "caaa9d531767d1ff2150b9332433f32a24622147e5ebb1f26409d5da67afd479"
 "checksum unicode-xid 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "826e7639553986605ec5979c7dd957c7895e93eabed50ab2ffa7f6128a75097c"
+"checksum uuid 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)" = "9fde2f6a4bea1d6e007c4ad38c6839fa71cbb63b6dbf5b595aa38dc9b1093c11"
 "checksum version_check 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "914b1a6776c4c929a602fafd8bc742e06365d4bcbe48c30f9cca5824f70dc9dd"
 "checksum walkdir 2.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "777182bc735b6424e1a57516d35ed72cb8019d85c8c9bf536dccb3445c1a2f7d"
 "checksum wasm-bindgen 0.2.58 (registry+https://github.com/rust-lang/crates.io-index)" = "5205e9afdf42282b192e2310a5b463a6d1c1d774e30dc3c791ac37ab42d2616c"

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -13,9 +13,16 @@ keywords    = ["hashing", "merkle", "protobufs", "security", "serialization"]
 
 [dependencies]
 displaydoc = { version = "0.1", default-features = false }
+tai64 = { version = "3", optional = true, default-features = false }
+uuid = { version = "0.8", optional = true, default-features = false }
 vint64 = { version = "0.2", path = "vint64" }
 
 [features]
-default = ["std"]
+default = ["builtins-std"]
 alloc = []
+builtins = ["tai64", "uuid"]
+builtins-std = ["std", "tai64/std", "uuid/std"]
 std = ["alloc"]
+
+[package.metadata.docs.rs]
+all-features = true

--- a/rust/src/builtins.rs
+++ b/rust/src/builtins.rs
@@ -1,0 +1,15 @@
+//! Built-in message types: Veriform's "standard library".
+//!
+//! These are the equivalent of Protobufs' "well-known types"
+
+#[cfg(feature = "tai64")]
+mod tai64;
+
+#[cfg(feature = "uuid")]
+mod uuid;
+
+#[cfg(feature = "tai64")]
+pub use self::tai64::TAI64N;
+
+#[cfg(feature = "uuid")]
+pub use self::uuid::Uuid;

--- a/rust/src/builtins/tai64.rs
+++ b/rust/src/builtins/tai64.rs
@@ -1,0 +1,64 @@
+//! TAI64(N) (Temps Atomique International) timestamps
+//!
+//! In Veriform these are encoded as:
+//!
+//! ```text
+//! message TAI64N {
+//!     secs[0]: !bytes(size = 8),
+//!     nanos[1]: bytes(size = 4)
+//! }
+//! ```
+
+pub use tai64::TAI64N;
+
+use crate::{
+    decoder::{Decodable, Decoder},
+    encoder::Encoder,
+    error::Error,
+    field::{self, WireType},
+    message::Message,
+};
+use core::convert::TryInto;
+
+impl Message for TAI64N {
+    fn decode(bytes: impl AsRef<[u8]>) -> Result<Self, Error> {
+        let mut bytes = bytes.as_ref();
+        let mut decoder = Decoder::new();
+
+        decoder.decode_expected_header(&mut bytes, 0, WireType::UInt64)?;
+        let secs = decoder.decode_uint64(&mut bytes)?;
+
+        decoder.decode_expected_header(&mut bytes, 1, WireType::UInt64)?;
+        let nanos = decoder.decode_uint64(&mut bytes)?;
+
+        if nanos > core::u32::MAX as u64 {
+            return Err(Error::Length);
+        }
+
+        let mut bytes = [0u8; 12];
+        bytes[..8].copy_from_slice(&secs.to_le_bytes());
+        bytes[8..].copy_from_slice(&(nanos as u32).to_le_bytes());
+        bytes.try_into().map_err(|_| Error::Builtin)
+    }
+
+    fn encode<'a>(&self, buffer: &'a mut [u8]) -> Result<&'a mut [u8], Error> {
+        let mut encoder = Encoder::new(buffer);
+        let (secs, nanos) = tai64_to_ints(self);
+        encoder.uint64(0, true, secs)?;
+        encoder.uint64(1, false, nanos as u64)?;
+        Ok(encoder.finish())
+    }
+
+    fn encoded_len(&self) -> usize {
+        let (secs, nanos) = tai64_to_ints(self);
+        field::length::uint64(0, secs) + field::length::uint64(1, nanos as u64)
+    }
+}
+
+/// Convert a TAI64N timestamp to two integers
+fn tai64_to_ints(tai64n: &TAI64N) -> (u64, u32) {
+    let encoded = tai64n.to_bytes();
+    let secs = u64::from_le_bytes(encoded[..8].try_into().unwrap());
+    let nanos = u32::from_le_bytes(encoded[8..].try_into().unwrap());
+    (secs, nanos)
+}

--- a/rust/src/builtins/uuid.rs
+++ b/rust/src/builtins/uuid.rs
@@ -1,0 +1,45 @@
+//! Universally unique identifiers.
+//!
+//! In Veriform these are encoded as:
+//!
+//! ```text
+//! message UUID {
+//!     value[0]: !bytes(size = 16),
+//! }
+//! ```
+
+pub use uuid::Uuid;
+
+use crate::{
+    decoder::{Decodable, Decoder},
+    encoder::Encoder,
+    error::Error,
+    field::{self, WireType},
+    message::Message,
+};
+use core::convert::TryInto;
+
+impl Message for Uuid {
+    fn decode(bytes: impl AsRef<[u8]>) -> Result<Self, Error> {
+        let mut bytes = bytes.as_ref();
+        let mut decoder = Decoder::new();
+
+        decoder.decode_expected_header(&mut bytes, 0, WireType::String)?;
+        let uuid_bytes = decoder.decode_bytes(&mut bytes)?;
+
+        uuid_bytes
+            .try_into()
+            .map(Uuid::from_bytes)
+            .map_err(|_| Error::Builtin)
+    }
+
+    fn encode<'a>(&self, buffer: &'a mut [u8]) -> Result<&'a mut [u8], Error> {
+        let mut encoder = Encoder::new(buffer);
+        encoder.bytes(0, true, self.as_bytes())?;
+        Ok(encoder.finish())
+    }
+
+    fn encoded_len(&self) -> usize {
+        field::length::bytes(0, self.as_bytes())
+    }
+}

--- a/rust/src/error.rs
+++ b/rust/src/error.rs
@@ -9,6 +9,9 @@ use displaydoc::Display;
 /// Error type
 #[derive(Copy, Clone, Debug, Display, Eq, PartialEq)]
 pub enum Error {
+    /// error decoding builtin type
+    Builtin,
+
     /// decoding failed: wire_type={wire_type:?}
     Decode {
         /// element of the message that failed to decode

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -16,6 +16,8 @@ extern crate alloc;
 #[cfg(feature = "std")]
 extern crate std;
 
+#[cfg(any(feature = "tai64", feature = "uuid"))]
+pub mod builtins;
 pub mod decoder;
 pub mod encoder;
 pub mod error;


### PR DESCRIPTION
Adds [TAI64N] timestamps and UUIDs as types which can be encoded as Veriform messages.

Veriform "builtins" are the equivalent of Protobufs "well-known types".

[TAI64N]: https://crates.io/crates/tai64