### PR TITLE
vint64: move `signed` and `zigzag` encoders into their own module:

### DIFF
--- a/rust/src/decoder/message/value.rs
+++ b/rust/src/decoder/message/value.rs
@@ -2,7 +2,10 @@
 
 use super::State;
 use crate::{
-    decoder::{vint64, Event},
+    decoder::{
+        vint64::{self, zigzag},
+        Event,
+    },
     error::Error,
     field::WireType,
 };
@@ -34,7 +37,7 @@ impl Decoder {
                 WireType::False => Event::Bool(false),
                 WireType::True => Event::Bool(true),
                 WireType::UInt64 => Event::UInt64(value),
-                WireType::SInt64 => Event::SInt64(vint64::decode_zigzag(value)),
+                WireType::SInt64 => Event::SInt64(zigzag::decode(value)),
                 WireType::Sequence => Event::SequenceHeader {
                     wire_type: WireType::from_unmasked(value),
                     length: (value >> 4) as usize,

--- a/rust/src/decoder/sequence.rs
+++ b/rust/src/decoder/sequence.rs
@@ -1,6 +1,9 @@
 //! Sequence decoder
 
-use super::{vint64, Decodable, Event};
+use super::{
+    vint64::{self, zigzag},
+    Decodable, Event,
+};
 use crate::{error::Error, field::WireType, message::Element};
 
 /// Sequence decoder
@@ -163,7 +166,7 @@ impl State {
                 if let Some(value) = decoder.decode(input)? {
                     match wire_type {
                         WireType::UInt64 => Event::UInt64(value),
-                        WireType::SInt64 => Event::SInt64(vint64::decode_zigzag(value)),
+                        WireType::SInt64 => Event::SInt64(zigzag::decode(value)),
                         WireType::Sequence => Event::SequenceHeader {
                             wire_type: WireType::from_unmasked(value),
                             length: (value >> 4) as usize,

--- a/rust/src/decoder/vint64.rs
+++ b/rust/src/decoder/vint64.rs
@@ -1,6 +1,6 @@
 //! Decoder for `vint64` values
 
-pub(crate) use vint64::decode_zigzag;
+pub(crate) use vint64::zigzag;
 
 use crate::error::Error;
 

--- a/rust/src/encoder.rs
+++ b/rust/src/encoder.rs
@@ -30,7 +30,7 @@ impl<'a> Encoder<'a> {
     /// Write a field containing a signed 64-bit integer
     pub fn sint64(&mut self, tag: Tag, critical: bool, value: i64) -> Result<(), Error> {
         self.write_header(tag, critical, WireType::SInt64)?;
-        self.write(vint64::encode_signed(value))
+        self.write(vint64::signed::encode(value))
     }
 
     /// Write a message (nested inside of a field)

--- a/rust/src/field/length.rs
+++ b/rust/src/field/length.rs
@@ -10,7 +10,7 @@ pub fn uint64(tag: Tag, value: u64) -> usize {
 
 /// Compute length of an `sint64` field
 pub fn sint64(tag: Tag, value: i64) -> usize {
-    header(tag, WireType::SInt64) + vint64::encode_signed(value).len()
+    header(tag, WireType::SInt64) + vint64::signed::encode(value).len()
 }
 
 /// Compute length of a `bytes` field


### PR DESCRIPTION
- `vint64::encode_signed` => `vint64::signed::encode`
- `vint64::decode_signed` => `vint64::signed::decode`
- `vint64::encode_zigzag` => `vint64::zigzag::encode`
- `vint64::decode_zigzag` => `vint64::zigzag::decode`