### PR TITLE
vint64.rs v0.3.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -563,7 +563,7 @@ checksum = "914b1a6776c4c929a602fafd8bc742e06365d4bcbe48c30f9cca5824f70dc9dd"
 
 [[package]]
 name = "vint64"
-version = "0.2.1"
+version = "0.3.0"
 dependencies = [
  "criterion",
  "criterion-cycles-per-byte",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -15,7 +15,7 @@ keywords    = ["hashing", "merkle", "protobufs", "security", "serialization"]
 displaydoc = { version = "0.1", default-features = false }
 tai64 = { version = "3", optional = true, default-features = false }
 uuid = { version = "0.8", optional = true, default-features = false }
-vint64 = { version = "0.2", path = "vint64" }
+vint64 = { version = "0.3", path = "vint64" }
 
 [features]
 default = ["builtins-std"]

--- a/rust/vint64/CHANGES.md
+++ b/rust/vint64/CHANGES.md
@@ -1,7 +1,19 @@
+## [0.3.0] (2020-02-28)
+
+- Add `encoded_len()`/`decoded_len()` helpers; loop-free encoder ([#103])
+- Use an `enum` for the `Error` type ([#102])
+- Move `signed` and `zigzag` encoders into their own modules ([#101])
+
+[0.3.0]: https://github.com/iqlusioninc/veriform/pull/104
+[#103]: https://github.com/iqlusioninc/veriform/pull/103
+[#102]: https://github.com/iqlusioninc/veriform/pull/102
+[#101]: https://github.com/iqlusioninc/veriform/pull/101
+
 ## [0.2.1] (2020-02-25)
 
 - Add `encode_zigzag` and `decode_zigzag` functions ([#76])
 
+[0.2.1]: https://github.com/iqlusioninc/veriform/pull/82
 [#76]: https://github.com/iqlusioninc/veriform/pull/76
 
 ## [0.2.0] (2020-02-14)

--- a/rust/vint64/Cargo.toml
+++ b/rust/vint64/Cargo.toml
@@ -4,7 +4,7 @@ description = """
 Simple and efficient variable-length integer encoding compatible with some
 variants of VLQ (Variable-Length Quantity)
 """
-version     = "0.2.1" # Also update html_root_url in lib.rs when bumping this
+version     = "0.3.0" # Also update html_root_url in lib.rs when bumping this
 authors     = ["Tony Arcieri <tony@iqlusion.io>"]
 license     = "Apache-2.0"
 edition     = "2018"

--- a/rust/vint64/src/lib.rs
+++ b/rust/vint64/src/lib.rs
@@ -72,7 +72,7 @@
 //! [Matroska]: https://www.matroska.org/
 
 #![no_std]
-#![doc(html_root_url = "https://docs.rs/vint64/0.2.1")]
+#![doc(html_root_url = "https://docs.rs/vint64/0.3.0")]
 #![forbid(unsafe_code)]
 #![warn(missing_docs, rust_2018_idioms, unused_qualifications)]
 


### PR DESCRIPTION
- Add `encoded_len()`/`decoded_len()` helpers; loop-free encoder ([#103])
- Use an `enum` for the `Error` type ([#102])
- Move `signed` and `zigzag` encoders into their own modules ([#101])

[0.3.0]: https://github.com/iqlusioninc/veriform/pull/104
[#103]: https://github.com/iqlusioninc/veriform/pull/103
[#102]: https://github.com/iqlusioninc/veriform/pull/102
[#101]: https://github.com/iqlusioninc/veriform/pull/101