### PR TITLE
vint64: factor modules into files

### DIFF
--- a/rust/src/decoder/vint64.rs
+++ b/rust/src/decoder/vint64.rs
@@ -1,6 +1,6 @@
 //! Decoder for `vint64` values
 
-pub(crate) use vint64::zigzag;
+pub(crate) use vint64::signed::zigzag;
 
 use crate::error::Error;
 

--- a/rust/vint64/src/error.rs
+++ b/rust/vint64/src/error.rs
@@ -1,0 +1,22 @@
+//! Error type
+
+use core::fmt::{self, Display};
+
+/// Error type
+#[derive(Copy, Clone, Debug)]
+pub enum Error {
+    /// Value contains unnecessary leading zeroes
+    LeadingZeroes,
+
+    /// Value is truncated / malformed
+    Truncated,
+}
+
+impl Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(match self {
+            Error::LeadingZeroes => "leading zeroes in vint64 value",
+            Error::Truncated => "truncated vint64 value",
+        })
+    }
+}

--- a/rust/vint64/src/signed.rs
+++ b/rust/vint64/src/signed.rs
@@ -1,0 +1,36 @@
+//! Support for encoding signed integers as `vint64`.
+
+use crate::{Error, VInt64};
+
+/// Encode a signed integer as a zigzag-encoded `vint64`.
+pub fn encode(value: i64) -> VInt64 {
+    value.into()
+}
+
+/// Decode a zigzag-encoded `vint64` as a signed integer.
+pub fn decode(input: &mut &[u8]) -> Result<i64, Error> {
+    super::decode(input).map(zigzag::decode)
+}
+
+/// Get the length of a zigzag encoded `vint64` for the given value in bytes.
+pub fn encoded_len(value: i64) -> usize {
+    super::encoded_len(zigzag::encode(value))
+}
+
+/// Zigzag encoding for signed integers.
+///
+/// This module contains the raw zigzag encoding algorithm.
+///
+/// For encoding signed integers as `vint64`, use the functions located in
+/// the parent [`vint64::signed`](../index.html) module.
+pub mod zigzag {
+    /// Encode a signed 64-bit integer in zigzag encoding
+    pub fn encode(value: i64) -> u64 {
+        ((value << 1) ^ (value >> 63)) as u64
+    }
+
+    /// Decode a signed 64-bit integer from zigzag encoding
+    pub fn decode(encoded: u64) -> i64 {
+        (encoded >> 1) as i64 ^ -((encoded & 1) as i64)
+    }
+}


### PR DESCRIPTION
Separates the `signed` and `error` modules into their own files, and moves the `zigzag` module under `signed`.