### PR TITLE
vint64: add off-by-default `std` feature

### DIFF
--- a/rust/vint64/Cargo.toml
+++ b/rust/vint64/Cargo.toml
@@ -18,6 +18,9 @@ keywords    = ["encoding", "integer", "leb128", "varint", "vlq"]
 criterion = "0.3"
 criterion-cycles-per-byte = "0.1"
 
+[features]
+std = []
+
 [[bench]]
 name = "vint64"
 harness = false

--- a/rust/vint64/src/error.rs
+++ b/rust/vint64/src/error.rs
@@ -20,3 +20,6 @@ impl Display for Error {
         })
     }
 }
+
+#[cfg(feature = "std")]
+impl std::error::Error for Error {}


### PR DESCRIPTION
Used only to provide a `std::error::Error` impl on the `Error` type.