### PR TITLE
vint64.rs v1.0.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -520,7 +520,7 @@ dependencies = [
 
 [[package]]
 name = "vint64"
-version = "0.3.0"
+version = "1.0.0"
 dependencies = [
  "criterion",
  "criterion-cycles-per-byte",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -15,7 +15,7 @@ keywords    = ["hashing", "merkle", "protobufs", "security", "serialization"]
 displaydoc = { version = "0.1", default-features = false }
 tai64 = { version = "3", optional = true, default-features = false }
 uuid = { version = "0.8", optional = true, default-features = false }
-vint64 = { version = "0.3", path = "vint64" }
+vint64 = { version = "1", path = "vint64" }
 
 [features]
 default = ["builtins-std"]

--- a/rust/vint64/CHANGES.md
+++ b/rust/vint64/CHANGES.md
@@ -1,3 +1,12 @@
+## [1.0.0] (2020-03-17)
+
+- Add off-by-default `std` feature ([#108])
+- Move `zigzag` module under `signed` ([#107])
+
+[1.0.0]: https://github.com/iqlusioninc/veriform/pull/109
+[#108]: https://github.com/iqlusioninc/veriform/pull/108
+[#107]: https://github.com/iqlusioninc/veriform/pull/107
+
 ## [0.3.0] (2020-02-28)
 
 - Add `encoded_len()`/`decoded_len()` helpers; loop-free encoder ([#103])

--- a/rust/vint64/Cargo.toml
+++ b/rust/vint64/Cargo.toml
@@ -4,7 +4,7 @@ description = """
 Simple and efficient variable-length integer encoding compatible with some
 variants of VLQ (Variable-Length Quantity)
 """
-version     = "0.3.0" # Also update html_root_url in lib.rs when bumping this
+version     = "1.0.0" # Also update html_root_url in lib.rs when bumping this
 authors     = ["Tony Arcieri <tony@iqlusion.io>"]
 license     = "Apache-2.0"
 edition     = "2018"

--- a/rust/vint64/src/lib.rs
+++ b/rust/vint64/src/lib.rs
@@ -72,7 +72,7 @@
 //! [Matroska]: https://www.matroska.org/
 
 #![no_std]
-#![doc(html_root_url = "https://docs.rs/vint64/0.3.0")]
+#![doc(html_root_url = "https://docs.rs/vint64/1.0.0")]
 #![forbid(unsafe_code)]
 #![warn(missing_docs, rust_2018_idioms, unused_qualifications)]
 


### PR DESCRIPTION
- Add off-by-default `std` feature ([#108])
- Move `zigzag` module under `signed` ([#107])

[#108]: https://github.com/iqlusioninc/veriform/pull/108
[#107]: https://github.com/iqlusioninc/veriform/pull/107