### PR TITLE
Use leading zeroes intrinsic

### DIFF
--- a/rust/vint64/src/lib.rs
+++ b/rust/vint64/src/lib.rs
@@ -73,7 +73,7 @@
 
 #![no_std]
 #![doc(html_root_url = "https://docs.rs/vint64/1.0.0")]
-#![forbid(unsafe_code)]
+// #![forbid(unsafe_code)]
 #![warn(missing_docs, rust_2018_idioms, unused_qualifications)]
 
 #[cfg(feature = "std")]
@@ -160,9 +160,9 @@ pub fn encoded_len(value: u64) -> usize {
         // 0x0000_0000_0000_0080..=0x0000_0000_0000_3fff => 2,
         50..=56 => 2,
         // 0x0000_0000_0000_0000..=0x0000_0000_0000_007f => 1,
-        _ => 1,
-        // _ => #[allow(unsafe)] unsafe { core::hint::unreachable_unchecked() }
-    }
+        57..=64 => 1,
+        _ => unsafe { core::hint::unreachable_unchecked() }
+,    }
 }
 
 /// Get the length of a `vint64` from the first byte.

--- a/rust/vint64/src/lib.rs
+++ b/rust/vint64/src/lib.rs
@@ -142,16 +142,26 @@ impl TryFrom<&[u8]> for VInt64 {
 
 /// Get the length of an encoded `vint64` for the given value in bytes.
 pub fn encoded_len(value: u64) -> usize {
-    match value {
-        0..=0x7f => 1,
-        0x80..=0x3fff => 2,
-        0x4000..=0xfffff => 3,
-        0x10_0000..=0xfff_ffff => 4,
-        0x1000_0000..=0x7_ffff_ffff => 5,
-        0x8_0000_0000..=0x3ff_ffff_ffff => 6,
-        0x400_0000_0000..=0x1_ffff_ffff_ffff => 7,
-        0x2_0000_0000_0000..=0xff_ffff_ffff_ffff => 8,
-        0x100_0000_0000_0000..=0xffff_ffff_ffff_ffff => 9,
+    match value.leading_zeros() {
+        // 0x0100_0000_0000_0000..=0xffff_ffff_ffff_ffff => 9,
+        0..=7 => 9,
+        // 0x0002_0000_0000_0000..=0x00ff_ffff_ffff_ffff => 8,
+        8..=14 => 8,
+        // 0x0000_0400_0000_0000..=0x0001_ffff_ffff_ffff => 7,
+        15..=21 => 7,
+        // 0x0000_0008_0000_0000..=0x0000_03ff_ffff_ffff => 6,
+        22..=28 => 6,
+        // 0x0000_0000_1000_0000..=0x0000_0007_ffff_ffff => 5,
+        29..=35 => 5,
+        // 0x0000_0000_0010_0000..=0x0000_0000_0fff_ffff => 4,
+        36..=42 => 4,
+        // 0x0000_0000_0000_4000..=0x0000_0000_000f_ffff => 3,
+        43..=49 => 3,
+        // 0x0000_0000_0000_0080..=0x0000_0000_0000_3fff => 2,
+        50..=56 => 2,
+        // 0x0000_0000_0000_0000..=0x0000_0000_0000_007f => 1,
+        _ => 1,
+        // _ => #[allow(unsafe)] unsafe { core::hint::unreachable_unchecked() }
     }
 }
 
@@ -321,5 +331,12 @@ mod tests {
 
         let mut slice = [0xf0, 0x3b, 0xfc, 0xc3, 0x03].as_ref();
         assert_eq!(signed::decode(&mut slice).unwrap(), -0x0f0f_f0f0);
+    }
+
+    #[test]
+    fn roundtrip_problem() {
+        let x = encode(1048576);
+        let y = decode(&mut x.as_ref()).unwrap();
+        assert_eq!(y, 1048576);
     }
 }

--- a/rust/vint64/src/lib.rs
+++ b/rust/vint64/src/lib.rs
@@ -143,26 +143,17 @@ impl TryFrom<&[u8]> for VInt64 {
 /// Get the length of an encoded `vint64` for the given value in bytes.
 pub fn encoded_len(value: u64) -> usize {
     match value.leading_zeros() {
-        // 0x0100_0000_0000_0000..=0xffff_ffff_ffff_ffff => 9,
         0..=7 => 9,
-        // 0x0002_0000_0000_0000..=0x00ff_ffff_ffff_ffff => 8,
         8..=14 => 8,
-        // 0x0000_0400_0000_0000..=0x0001_ffff_ffff_ffff => 7,
         15..=21 => 7,
-        // 0x0000_0008_0000_0000..=0x0000_03ff_ffff_ffff => 6,
         22..=28 => 6,
-        // 0x0000_0000_1000_0000..=0x0000_0007_ffff_ffff => 5,
         29..=35 => 5,
-        // 0x0000_0000_0010_0000..=0x0000_0000_0fff_ffff => 4,
         36..=42 => 4,
-        // 0x0000_0000_0000_4000..=0x0000_0000_000f_ffff => 3,
         43..=49 => 3,
-        // 0x0000_0000_0000_0080..=0x0000_0000_0000_3fff => 2,
         50..=56 => 2,
-        // 0x0000_0000_0000_0000..=0x0000_0000_0000_007f => 1,
         57..=64 => 1,
-        _ => unsafe { core::hint::unreachable_unchecked() }
-,    }
+        _ => unsafe { core::hint::unreachable_unchecked() },
+    }
 }
 
 /// Get the length of a `vint64` from the first byte.

--- a/rust/vint64/src/lib.rs
+++ b/rust/vint64/src/lib.rs
@@ -73,8 +73,7 @@
 
 #![no_std]
 #![doc(html_root_url = "https://docs.rs/vint64/1.0.0")]
-// #![forbid(unsafe_code)]
-#![warn(missing_docs, rust_2018_idioms, unused_qualifications)]
+#![warn(missing_docs, rust_2018_idioms, unused_qualifications, unsafe_code)]
 
 #[cfg(feature = "std")]
 extern crate std;
@@ -152,7 +151,18 @@ pub fn encoded_len(value: u64) -> usize {
         43..=49 => 3,
         50..=56 => 2,
         57..=64 => 1,
-        _ => unsafe { core::hint::unreachable_unchecked() },
+        _ => {
+            // SAFETY:
+            //
+            // The `leading_zeros` intrinsic returns the number of bits that
+            // contain a zero bit. The result will always be in the range of
+            // 0..=64 for a `u64`, so the above pattern is exhaustive, however
+            // it is not exhaustive over the return type of `u32`. Because of
+            // this, we mark the "uncovered" part of the match as unreachable
+            // for performance reasons.
+            #[allow(unsafe_code)]
+            unsafe { core::hint::unreachable_unchecked() }
+        },
     }
 }
 

--- a/rust/vint64/src/lib.rs
+++ b/rust/vint64/src/lib.rs
@@ -161,8 +161,10 @@ pub fn encoded_len(value: u64) -> usize {
             // this, we mark the "uncovered" part of the match as unreachable
             // for performance reasons.
             #[allow(unsafe_code)]
-            unsafe { core::hint::unreachable_unchecked() }
-        },
+            unsafe {
+                core::hint::unreachable_unchecked()
+            }
+        }
     }
 }
 


### PR DESCRIPTION
Closes #111 

This uses the leading zeroes intrinsic, which gives a slight perf boost, as well as fixing the round trip issue, likely there is some wrong constant in the previous match impl.

```
     Running /tmp/.cargo-build-cache/release/deps/vint64-85b2e93ba12d6336
vint64/encode           time:   [5.5530 cycles 5.6138 cycles 5.6858 cycles]
                        change: [-7.5630% -6.5807% -5.8157%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 10 outliers among 100 measurements (10.00%)
  1 (1.00%) low mild
  7 (7.00%) high mild
  2 (2.00%) high severe
vint64/decode           time:   [16.3879 cycles 16.4438 cycles 16.5156 cycles]
                        change: [-0.1230% +1.7969% +3.7206%] (p = 0.08 > 0.05)
                        No change in performance detected.
Found 8 outliers among 100 measurements (8.00%)
  3 (3.00%) high mild
  5 (5.00%) high severe
```