### PR TITLE
Just fix constants, include leading zeros in constants and comments

### DIFF
--- a/rust/vint64/src/lib.rs
+++ b/rust/vint64/src/lib.rs
@@ -139,15 +139,24 @@ impl TryFrom<&[u8]> for VInt64 {
 /// Get the length of an encoded `vint64` for the given value in bytes.
 pub fn encoded_len(value: u64) -> usize {
     match value {
-        0..=0x7f => 1,
-        0x80..=0x3fff => 2,
-        0x4000..=0xfffff => 3,
-        0x10_0000..=0xfff_ffff => 4,
-        0x1000_0000..=0x7_ffff_ffff => 5,
-        0x8_0000_0000..=0x3ff_ffff_ffff => 6,
-        0x400_0000_0000..=0x1_ffff_ffff_ffff => 7,
-        0x2_0000_0000_0000..=0xff_ffff_ffff_ffff => 8,
-        0x100_0000_0000_0000..=0xffff_ffff_ffff_ffff => 9,
+        // 64 -> 57  => 1
+        0x0000_0000_0000_0000..=0x0000_0000_0000_007f => 1,
+        // 56 -> 50  => 2
+        0x0000_0000_0000_0080..=0x0000_0000_0000_3fff => 2,
+        // 49 -> 43  => 3
+        0x0000_0000_0000_4000..=0x0000_0000_001f_ffff => 3,
+        // 42 -> 36  => 4
+        0x0000_0000_0020_0000..=0x0000_0000_0fff_ffff => 4,
+        // 35 -> 29  => 5
+        0x0000_0000_1000_0000..=0x0000_0007_ffff_ffff => 5,
+        // 28 -> 22  => 6
+        0x0000_0008_0000_0000..=0x0000_03ff_ffff_ffff => 6,
+        // 21 -> 15  => 7
+        0x0000_0400_0000_0000..=0x0001_ffff_ffff_ffff => 7,
+        // 14 ->  8  => 8
+        0x0002_0000_0000_0000..=0x00ff_ffff_ffff_ffff => 8,
+        //  7 ->  0  => 9
+        0x0100_0000_0000_0000..=0xffff_ffff_ffff_ffff => 9,
     }
 }
 
@@ -314,5 +323,12 @@ mod tests {
 
         let mut slice = [0xf0, 0x3b, 0xfc, 0xc3, 0x03].as_ref();
         assert_eq!(signed::decode(&mut slice).unwrap(), -0x0f0f_f0f0);
+    }
+
+    #[test]
+    fn roundtrip_problem() {
+        let x = encode(1048576);
+        let y = decode(&mut x.as_ref()).unwrap();
+        assert_eq!(y, 1048576);
     }
 }


### PR DESCRIPTION
Alternative fix to #111.

The constants were off by one bit on the border between 3 and 4 bytes of size.