### PR TITLE
vint64.rs v1.0.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -802,7 +802,7 @@ dependencies = [
 
 [[package]]
 name = "vint64"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "criterion",
  "criterion-cycles-per-byte",

--- a/rust/vint64/CHANGES.md
+++ b/rust/vint64/CHANGES.md
@@ -1,3 +1,14 @@
+## [1.0.1] (2020-03-30)
+
+- Use `proptest` crate to check round-trip behavior ([#114])
+- Use leading zeroes intrinsic - fixes critical bug ([#112])
+- Add `#[inline]` attributes ([#110])
+
+[1.0.1]: https://github.com/iqlusioninc/veriform/pull/115
+[#114]: https://github.com/iqlusioninc/veriform/pull/114
+[#112]: https://github.com/iqlusioninc/veriform/pull/112
+[#110]: https://github.com/iqlusioninc/veriform/pull/110
+
 ## [1.0.0] (2020-03-17)
 
 - Add off-by-default `std` feature ([#108])

--- a/rust/vint64/Cargo.toml
+++ b/rust/vint64/Cargo.toml
@@ -4,7 +4,7 @@ description = """
 Simple and efficient variable-length integer encoding compatible with some
 variants of VLQ (Variable-Length Quantity)
 """
-version     = "1.0.0" # Also update html_root_url in lib.rs when bumping this
+version     = "1.0.1" # Also update html_root_url in lib.rs when bumping this
 authors     = ["Tony Arcieri <tony@iqlusion.io>"]
 license     = "Apache-2.0"
 edition     = "2018"


### PR DESCRIPTION
- Use `proptest` crate to check round-trip behavior ([#114])
- Use leading zeroes intrinsic - fixes critical bug ([#112])
- Add `#[inline]` attributes ([#110])

[#114]: https://github.com/iqlusioninc/veriform/pull/114
[#112]: https://github.com/iqlusioninc/veriform/pull/112
[#110]: https://github.com/iqlusioninc/veriform/pull/110