### PR TITLE
rust: initial Verihash PoC

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -55,7 +55,7 @@ jobs:
         working-directory: rust
         env:
           RUSTFLAGS: -D warnings
-        run: cargo build --release --target ${{ matrix.target }} --no-default-features
+        run: cargo build --release --target ${{ matrix.target }} --no-default-features --features=sha2
 
   check:
     name: Check
@@ -169,12 +169,12 @@ jobs:
           toolchain: ${{ matrix.toolchain }}
           override: true
 
-      - name: Run cargo test --no-default-features --lib
+      - name: Run cargo test --no-default-features --features=sha2
         env:
           CARGO_INCREMENTAL: 0
           RUSTFLAGS: -D warnings
         working-directory: rust
-        run: cargo test --no-default-features --release
+        run: cargo test --no-default-features --features=sha2 --release
 
       - name: Run cargo test --release
         uses: actions-rs/cargo@v1

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -56,6 +56,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf1de2fe8c75bc145a2f577add951f8134889b4795d47466a54a5c846d691693"
 
 [[package]]
+name = "block-buffer"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0940dc441f31689269e10ac70eb1002a3a1d3ad1390e030043662eb7fe4688b"
+dependencies = [
+ "block-padding",
+ "byte-tools",
+ "byteorder",
+ "generic-array 0.12.3",
+]
+
+[[package]]
+name = "block-padding"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa79dedbb091f449f1f39e53edf88d5dbe95f895dae6135a8d7b881fb5af73f5"
+dependencies = [
+ "byte-tools",
+]
+
+[[package]]
 name = "bstr"
 version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -72,6 +93,12 @@ name = "bumpalo"
 version = "3.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f359dc14ff8911330a51ef78022d376f25ed00248912803b58f00cb1c27f742"
+
+[[package]]
+name = "byte-tools"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3b5ca7a04898ad4bcd41c90c5285445ff5b791899bb1b0abdd2a2aa791211d7"
 
 [[package]]
 name = "byteorder"
@@ -228,6 +255,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "digest"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3d0c8c8752312f9713efd397ff63acb9f85585afbf179282e720e7704954dd5"
+dependencies = [
+ "generic-array 0.12.3",
+]
+
+[[package]]
 name = "displaydoc"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -243,6 +279,12 @@ name = "either"
 version = "1.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bb1f6b1ce1c140482ea30ddd3335fc0024ac7ee112895426e0a629a6c20adfe3"
+
+[[package]]
+name = "fake-simd"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e88a8acf291dafb59c2d96e8f59828f3838bb1a70398823ade51a84de6a6deed"
 
 [[package]]
 name = "fnv"
@@ -405,6 +447,12 @@ name = "oorandom"
 version = "11.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebcec7c9c2a95cacc7cd0ecb89d8a8454eca13906f6deb55258ffff0adeb9405"
+
+[[package]]
+name = "opaque-debug"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2839e79665f131bdb5782e51f2c6c9599c133c6098982a54c794358bf432529c"
 
 [[package]]
 name = "plotters"
@@ -773,6 +821,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha2"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "27044adfd2e1f077f649f59deb9490d3941d674002f7d062870a60ebe9bd47a0"
+dependencies = [
+ "block-buffer",
+ "digest",
+ "fake-simd",
+ "opaque-debug",
+]
+
+[[package]]
 name = "stable_deref_trait"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -856,9 +916,11 @@ checksum = "9fde2f6a4bea1d6e007c4ad38c6839fa71cbb63b6dbf5b595aa38dc9b1093c11"
 name = "veriform"
 version = "0.0.1"
 dependencies = [
+ "digest",
  "displaydoc",
  "heapless",
  "log",
+ "sha2",
  "tai64",
  "uuid",
  "vint64",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -12,15 +12,17 @@ categories  = ["authentication", "cryptography", "encoding"]
 keywords    = ["hashing", "merkle", "protobufs", "security", "serialization"]
 
 [dependencies]
+digest = { version = "0.8", default-features = false }
 displaydoc = { version = "0.1", default-features = false }
 heapless = "0.5"
 log = { version = "0.4", optional = true }
+sha2 = { version = "0.8", optional = true, default-features = false }
 tai64 = { version = "3", optional = true, default-features = false }
 uuid = { version = "0.8", optional = true, default-features = false }
 vint64 = { version = "1", path = "vint64" }
 
 [features]
-default = ["builtins-std"]
+default = ["builtins-std", "sha2"]
 alloc = []
 builtins = ["tai64", "uuid"]
 builtins-std = ["std", "tai64/std", "uuid/std"]

--- a/rust/src/builtins/timestamp.rs
+++ b/rust/src/builtins/timestamp.rs
@@ -11,11 +11,18 @@
 
 pub use tai64::TAI64N as Timestamp;
 
-use crate::{decoder::Decode, field, Decoder, Encoder, Error, Message};
+use crate::{
+    decoder::{Decode, Decoder},
+    digest::Digest,
+    field, Encoder, Error, Message,
+};
 use core::convert::TryInto;
 
 impl Message for Timestamp {
-    fn decode(decoder: &mut Decoder, mut input: &[u8]) -> Result<Self, Error> {
+    fn decode<D>(decoder: &mut Decoder<D>, mut input: &[u8]) -> Result<Self, Error>
+    where
+        D: Digest,
+    {
         let secs: u64 = decoder.decode(0, &mut input)?;
         let nanos: u64 = decoder.decode(1, &mut input)?;
 

--- a/rust/src/builtins/uuid.rs
+++ b/rust/src/builtins/uuid.rs
@@ -12,12 +12,16 @@ pub use uuid::Uuid;
 
 use crate::{
     decoder::{DecodeRef, Decoder},
+    digest::Digest,
     field, Encoder, Error, Message,
 };
 use core::convert::TryInto;
 
 impl Message for Uuid {
-    fn decode(decoder: &mut Decoder, mut input: &[u8]) -> Result<Self, Error> {
+    fn decode<D>(decoder: &mut Decoder<D>, mut input: &[u8]) -> Result<Self, Error>
+    where
+        D: Digest,
+    {
         let bytes: &[u8] = decoder.decode_ref(0, &mut input)?;
 
         bytes

--- a/rust/src/decoder/hasher.rs
+++ b/rust/src/decoder/hasher.rs
@@ -1,0 +1,299 @@
+//! Verihash message hasher.
+//!
+//! WARNING: this is an experimental PoC-quality implementation!
+//! It is NOT suitable for production use!
+
+// TODO(tarcieri): tests and test vectors!!!
+
+use crate::{
+    decoder::Event,
+    error::Error,
+    field::{self, Tag, WireType},
+};
+use core::fmt::{self, Debug};
+use digest::Digest;
+
+/// Verihash prefix used by tags (unsigned integer)
+const TAG_PREFIX: u8 = WireType::UInt64.to_u8();
+
+/// Verihash message hasher.
+///
+/// This type computes a hash-based transcript of how a message was
+/// decoded, driven by incoming decoding events.
+pub struct Hasher<D: Digest> {
+    /// Computed digest in-progress
+    digest: D,
+
+    /// Current state of the decoder (or `None` if an error occurred)
+    state: Option<State>,
+}
+
+impl<D> Hasher<D>
+where
+    D: Digest,
+{
+    /// Create a new [`Hasher`]
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Hash an incoming event
+    pub fn hash_event(&mut self, event: &Event<'_>) -> Result<(), Error> {
+        if let Some(state) = self.state.take() {
+            let new_state = state.transition(event, &mut self.digest)?;
+            self.state = Some(new_state);
+            Ok(())
+        } else {
+            Err(Error::Failed)
+        }
+    }
+}
+
+impl<D> Default for Hasher<D>
+where
+    D: Digest,
+{
+    fn default() -> Self {
+        Self {
+            digest: D::new(),
+            state: Some(State::default()),
+        }
+    }
+}
+
+impl<D> Debug for Hasher<D>
+where
+    D: Digest,
+{
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("Hasher").finish()
+    }
+}
+
+#[derive(Debug, Eq, PartialEq)]
+enum State {
+    /// At the start of a message with no data processed
+    Initial,
+
+    /// Field header has been read
+    Header(field::Header),
+
+    /// Hashing a bytes field
+    Bytes { remaining: usize },
+
+    /// Hashing a string field
+    String { remaining: usize },
+
+    /// Hashing a message value
+    Message { remaining: usize },
+
+    /// Hashing a sequence value
+    Sequence { remaining: usize },
+}
+
+impl Default for State {
+    fn default() -> Self {
+        State::Initial
+    }
+}
+
+impl State {
+    /// Transition to a new state based on an incoming event or return an error
+    pub fn transition<D: Digest>(self, event: &Event<'_>, digest: &mut D) -> Result<Self, Error> {
+        match event {
+            Event::FieldHeader(header) => self.handle_field_header(header),
+            Event::LengthDelimiter { wire_type, length } => {
+                self.handle_length_delimiter(*wire_type, *length, digest)
+            }
+            Event::Bool(_) | Event::UInt64(_) | Event::SInt64(_) => {
+                self.handle_fixed_sized_value(event, digest)
+            }
+            Event::ValueChunk {
+                wire_type,
+                bytes,
+                remaining,
+            } => self.handle_value_chunk(*wire_type, bytes, *remaining, digest),
+            Event::SequenceHeader { wire_type, length } => {
+                self.handle_sequence_header(*wire_type, *length)
+            }
+        }
+    }
+
+    /// Handle an incoming field header
+    fn handle_field_header(self, header: &field::Header) -> Result<Self, Error> {
+        if self == State::Initial {
+            Ok(State::Header(*header))
+        } else {
+            Err(Error::Hashing)
+        }
+    }
+
+    /// Handle length delimiter event
+    fn handle_length_delimiter<D: Digest>(
+        self,
+        wire_type: WireType,
+        length: usize,
+        digest: &mut D,
+    ) -> Result<Self, Error> {
+        if let State::Header(header) = self {
+            if wire_type != header.wire_type {
+                return Err(Error::Hashing);
+            }
+
+            let new_state = match wire_type {
+                WireType::Bytes => State::Bytes { remaining: length },
+                WireType::String => State::String { remaining: length },
+                WireType::Message => State::Message { remaining: length },
+                WireType::Sequence => State::Sequence { remaining: length },
+                _ => unreachable!(),
+            };
+
+            hash_dynamically_sized_value(digest, header.tag, wire_type, length);
+
+            Ok(new_state)
+        } else {
+            Err(Error::Hashing)
+        }
+    }
+
+    /// Handle hashing an incoming fixed-width value
+    fn handle_fixed_sized_value<D: Digest>(
+        self,
+        value: &Event<'_>,
+        digest: &mut D,
+    ) -> Result<Self, Error> {
+        if let State::Header(header) = self {
+            match value {
+                Event::Bool(value) => hash_boolean(digest, header.tag, *value),
+                Event::UInt64(value) => hash_uint64(digest, header.tag, *value),
+                Event::SInt64(value) => hash_sint64(digest, header.tag, *value),
+                _ => unreachable!(),
+            }
+        } else {
+            return Err(Error::Hashing);
+        }
+
+        Ok(State::Initial)
+    }
+
+    /// Handle an incoming chunk of data in a value
+    fn handle_value_chunk<D: Digest>(
+        self,
+        wire_type: WireType,
+        bytes: &[u8],
+        new_remaining: usize,
+        digest: &mut D,
+    ) -> Result<Self, Error> {
+        // TODO(tarcieri): DRY this out
+        let new_state = match self {
+            State::Bytes { remaining } => {
+                if wire_type != WireType::Bytes || remaining - bytes.len() != new_remaining {
+                    return Err(Error::Hashing);
+                }
+
+                if new_remaining == 0 {
+                    State::Initial
+                } else {
+                    State::Bytes {
+                        remaining: new_remaining,
+                    }
+                }
+            }
+            State::String { remaining } => {
+                // TODO(tarcieri): use `unicode-normalization`?
+
+                if wire_type != WireType::String || remaining - bytes.len() != new_remaining {
+                    return Err(Error::Hashing);
+                }
+
+                if new_remaining == 0 {
+                    State::Initial
+                } else {
+                    State::String {
+                        remaining: new_remaining,
+                    }
+                }
+            }
+            State::Message { remaining } => {
+                if wire_type != WireType::Message || remaining - bytes.len() != new_remaining {
+                    return Err(Error::Hashing);
+                }
+
+                if new_remaining == 0 {
+                    return Ok(State::Initial);
+                } else {
+                    return Ok(State::Bytes {
+                        remaining: new_remaining,
+                    });
+                }
+            }
+            State::Sequence { remaining } => {
+                if wire_type != WireType::Sequence || remaining - bytes.len() != new_remaining {
+                    return Err(Error::Hashing);
+                }
+
+                if new_remaining == 0 {
+                    return Ok(State::Initial);
+                } else {
+                    return Ok(State::Bytes {
+                        remaining: new_remaining,
+                    });
+                }
+            }
+            _ => {
+                return Err(Error::Hashing);
+            }
+        };
+
+        digest.input(bytes);
+        Ok(new_state)
+    }
+
+    /// Handle an incoming sequence header
+    fn handle_sequence_header(self, _wire_type: WireType, _length: usize) -> Result<Self, Error> {
+        // TODO(tarcieri): handle sequence headers correctly!
+        Ok(self)
+    }
+}
+
+/// Hash a boolean
+pub fn hash_boolean<D: Digest>(digest: &mut D, tag: Tag, value: bool) {
+    let (wire_type, body) = if value {
+        (WireType::True, b"\x01")
+    } else {
+        (WireType::False, b"\x00")
+    };
+
+    hash_fixed(digest, tag, wire_type, body);
+}
+
+/// Hash an unsigned integer
+pub fn hash_uint64<D: Digest>(digest: &mut D, tag: Tag, value: u64) {
+    hash_fixed(digest, tag, WireType::UInt64, &value.to_le_bytes());
+}
+
+/// Hash a signed integer
+pub fn hash_sint64<D: Digest>(digest: &mut D, tag: Tag, value: i64) {
+    hash_fixed(digest, tag, WireType::SInt64, &value.to_le_bytes());
+}
+
+/// Hash bytes
+pub fn hash_dynamically_sized_value<D: Digest>(
+    digest: &mut D,
+    tag: Tag,
+    wire_type: WireType,
+    length: usize,
+) {
+    digest.input(&[TAG_PREFIX]);
+    digest.input(&tag.to_le_bytes());
+    digest.input(&[wire_type.to_u8()]);
+    digest.input(&(length as u64).to_le_bytes());
+}
+
+/// Hash a fixed-width value with the given wiretype
+fn hash_fixed<D: Digest>(digest: &mut D, tag: Tag, wire_type: WireType, body: &[u8]) {
+    digest.input(&[TAG_PREFIX]);
+    digest.input(&tag.to_le_bytes());
+    digest.input(&[wire_type.to_u8()]);
+    digest.input(body);
+}

--- a/rust/src/decoder/sequence/iter.rs
+++ b/rust/src/decoder/sequence/iter.rs
@@ -4,6 +4,10 @@ use super::Decoder;
 use crate::{decoder::Decodable, Error, Message};
 use core::marker::PhantomData;
 
+// TODO(tarcieri): make this (and `sequence::Decoder`) generic around digest
+#[cfg(not(feature = "sha2"))]
+compile_error!("TODO: support disabling `sha2` feature");
+
 /// Sequence iterator: iterates over a sequence of values in a Veriform
 /// message, decoding each one.
 pub struct Iter<'a, T> {
@@ -38,7 +42,7 @@ impl<'a, T: Message> Iterator for Iter<'a, T> {
 
         let mut input = &self.data[self.decoder.position()..];
 
-        // TODO(tarcieri): reuse decoder
+        // TODO(tarcieri): reuse decoder; support disabling `sha2` feature
         let mut decoder = crate::Decoder::new();
 
         let result = self

--- a/rust/src/decoder/trace.rs
+++ b/rust/src/decoder/trace.rs
@@ -1,0 +1,19 @@
+//! Message tracing macros
+
+/// Trace a decoding event
+macro_rules! trace {
+    ($decoder:expr, $c:expr, $msg:expr, $($arg:tt)*) => {
+        let mut prefix: heapless::String<heapless::consts::U128> = heapless::String::new();
+        for _ in 0..$decoder.depth() {
+            prefix.push($c).unwrap();
+        }
+        log::trace!(concat!("{}", $msg), &prefix, $($arg)*);
+    }
+}
+
+/// Trace the beginning of a message component being decoded
+macro_rules! begin {
+    ($decoder:expr, $msg:expr, $($arg:tt)*) => {
+        trace!($decoder, '+', $msg, $($arg)*);
+    }
+}

--- a/rust/src/decoder/traits.rs
+++ b/rust/src/decoder/traits.rs
@@ -1,0 +1,36 @@
+//! Message decoding traits.
+//!
+//! These traits infer the wire type to decode using the type system.
+//!
+//! They're intened to be impl'd by `veriform::decoder::Decoder`.
+
+use super::sequence;
+use crate::{error::Error, field::Tag};
+
+/// Try to decode a field to a value of the given type.
+///
+/// This trait is intended to be impl'd by the [`Decoder`] type.
+pub trait Decode<T> {
+    /// Try to decode a value of type `T`
+    fn decode(&mut self, tag: Tag, input: &mut &[u8]) -> Result<T, Error>;
+}
+
+/// Try to decode a field to a reference of the given type.
+///
+/// This trait is intended to be impl'd by the [`Decoder`] type.
+pub trait DecodeRef<T: ?Sized> {
+    /// Try to decode a reference to type `T`
+    fn decode_ref<'a>(&mut self, tag: Tag, input: &mut &'a [u8]) -> Result<&'a T, Error>;
+}
+
+/// Decode a sequence of values to a [`sequence::Iter`].
+///
+/// This trait is intended to be impl'd by the [`Decoder`] type.
+pub trait DecodeSeq<T> {
+    /// Try to decode a sequence of values of type `T`
+    fn decode_seq<'a>(
+        &mut self,
+        tag: Tag,
+        input: &mut &'a [u8],
+    ) -> Result<sequence::Iter<'a, T>, Error>;
+}

--- a/rust/src/encoder.rs
+++ b/rust/src/encoder.rs
@@ -141,13 +141,13 @@ impl<'a> Encoder<'a> {
     }
 }
 
-#[cfg(test)]
+#[cfg(all(test, feature = "sha2"))]
 mod tests {
     use super::Encoder;
-    use crate::{
-        decoder::{message::Decoder, Decodable},
-        field::WireType,
-    };
+    use crate::{decoder::Decodable, field::WireType};
+
+    // TODO(tarcieri): rewrite tests with `crate::Decoder`
+    type Decoder = crate::decoder::message::Decoder<sha2::Sha256>;
 
     const EXAMPLE_BYTES: &[u8] = b"foobar";
     const EXAMPLE_STRING: &str = "baz";

--- a/rust/src/error.rs
+++ b/rust/src/error.rs
@@ -33,6 +33,10 @@ pub enum Error {
         wire_type: Option<WireType>,
     },
 
+    /// hashing operation failed
+    // TODO(tarcieri): collect more info
+    Hashing,
+
     /// invalid wire type
     InvalidWireType,
 

--- a/rust/src/field/wire_type.rs
+++ b/rust/src/field/wire_type.rs
@@ -46,6 +46,11 @@ impl WireType {
             _ => false,
         }
     }
+
+    /// Convert a [`WireType`] to a byte representation
+    pub const fn to_u8(self) -> u8 {
+        self as u8
+    }
 }
 
 impl TryFrom<u64> for WireType {

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -24,12 +24,14 @@ pub mod error;
 pub mod field;
 pub mod message;
 
+// Re-export the `digest` crate
+pub use digest;
+
 // Re-export the `vint64` crate
 pub use vint64;
 
-pub use crate::{
-    decoder::{Decodable, Decoder},
-    encoder::Encoder,
-    error::Error,
-    message::Message,
-};
+pub use crate::{encoder::Encoder, error::Error, message::Message};
+
+/// Veriform decoder with the default SHA-256 hash
+#[cfg(feature = "sha2")]
+pub type Decoder = crate::decoder::Decoder<sha2::Sha256>;

--- a/rust/src/message.rs
+++ b/rust/src/message.rs
@@ -5,7 +5,8 @@
 //
 // Copyright (c) 2017 Dan Burkert and released under the Apache 2.0 license.
 
-use crate::{Decoder, Error};
+use crate::{decoder::Decoder, Error};
+use digest::Digest;
 
 #[cfg(feature = "alloc")]
 use alloc::vec::Vec;
@@ -30,8 +31,9 @@ pub enum Element {
 pub trait Message {
     /// Decode a Veriform message contained in the provided slice using the
     /// given [`Decoder`].
-    fn decode(decoder: &mut Decoder, input: &[u8]) -> Result<Self, Error>
+    fn decode<D>(decoder: &mut Decoder<D>, input: &[u8]) -> Result<Self, Error>
     where
+        D: Digest,
         Self: Sized;
 
     /// Encode this message as Veriform into the provided buffer, returning


### PR DESCRIPTION
This is a PoC implementation of Verihash. It is not yet fully correct and does not properly handle "non-terminals" (nested messages and sequences).

It's implemented as yet another handrolled state machine which processes incoming decoding events and incrementally computes a hash. In the future it might be nice to implement this in terms of something like session types instead (however this commit is spiking out the initial
protocol, which is still incomplete).

Having the hasher integrated directly into the decoder event system will eventually enable support for computing hashes of messages which contain unknown fields, as the decoder will (eventually) continue processing these fields anyway even if they weren't originally requested by the `Message` impl.