### PR TITLE
rust: nested Verihash (part 2) - initial sequence hashing

### DIFF
--- a/rust/src/decoder.rs
+++ b/rust/src/decoder.rs
@@ -5,7 +5,6 @@ pub mod sequence;
 
 mod decodable;
 mod event;
-mod hasher;
 mod traits;
 mod vint64;
 
@@ -16,7 +15,6 @@ mod trace;
 pub use self::{
     decodable::Decodable,
     event::Event,
-    hasher::Hasher,
     traits::{Decode, DecodeRef, DecodeSeq},
 };
 
@@ -159,7 +157,7 @@ where
     }
 }
 
-impl<D, M> DecodeSeq<M> for Decoder<D>
+impl<D, M> DecodeSeq<M, D> for Decoder<D>
 where
     D: Digest,
     M: Message,
@@ -168,7 +166,7 @@ where
         &mut self,
         tag: Tag,
         input: &mut &'a [u8],
-    ) -> Result<sequence::Iter<'a, M>, Error> {
+    ) -> Result<sequence::Iter<'a, M, D>, Error> {
         #[cfg(feature = "log")]
         begin!(self, "[{}]: seq<msg>?", tag);
 
@@ -180,7 +178,7 @@ where
     }
 }
 
-impl<D> DecodeSeq<u64> for Decoder<D>
+impl<D> DecodeSeq<u64, D> for Decoder<D>
 where
     D: Digest,
 {
@@ -188,7 +186,7 @@ where
         &mut self,
         tag: Tag,
         input: &mut &'a [u8],
-    ) -> Result<sequence::Iter<'a, u64>, Error> {
+    ) -> Result<sequence::Iter<'a, u64, D>, Error> {
         #[cfg(feature = "log")]
         begin!(self, "[{}]: seq<uint64>?", tag);
 
@@ -200,7 +198,7 @@ where
     }
 }
 
-impl<D> DecodeSeq<i64> for Decoder<D>
+impl<D> DecodeSeq<i64, D> for Decoder<D>
 where
     D: Digest,
 {
@@ -208,7 +206,7 @@ where
         &mut self,
         tag: Tag,
         input: &mut &'a [u8],
-    ) -> Result<sequence::Iter<'a, i64>, Error> {
+    ) -> Result<sequence::Iter<'a, i64, D>, Error> {
         #[cfg(feature = "log")]
         begin!(self, "[{}]: seq<sint64>?", tag);
 

--- a/rust/src/decoder/message.rs
+++ b/rust/src/decoder/message.rs
@@ -2,6 +2,7 @@
 
 mod body;
 mod decoder;
+mod hasher;
 mod header;
 mod state;
 mod value;

--- a/rust/src/decoder/message/decoder.rs
+++ b/rust/src/decoder/message/decoder.rs
@@ -1,8 +1,8 @@
 //! Veriform message decoder
 
-use super::state::State;
+use super::{hasher::Hasher, state::State};
 use crate::{
-    decoder::{Decodable, Event, Hasher},
+    decoder::{Decodable, Event},
     error::Error,
     field::{Header, Tag, WireType},
     message::Element,
@@ -144,7 +144,7 @@ where
             state: Some(State::default()),
             last_tag: None,
             position: 0,
-            hasher: Some(Hasher::new()),
+            hasher: Some(Hasher::new()), // TODO(tarcieri): support for disabling hasher
         }
     }
 }

--- a/rust/src/decoder/message/hasher.rs
+++ b/rust/src/decoder/message/hasher.rs
@@ -9,17 +9,16 @@
 //! - Sequence hashing
 
 // TODO(tarcieri): tests and test vectors!!!
+// TODO(tarcieri): DRY out repeated logic in sequence hasher
 
 use crate::{
     decoder::Event,
     error::Error,
     field::{self, Tag, WireType},
+    verihash::*,
 };
 use core::fmt::{self, Debug};
 use digest::{generic_array::GenericArray, Digest};
-
-/// Verihash prefix used by tags (unsigned integer)
-const TAG_PREFIX: u8 = WireType::UInt64.to_u8();
 
 /// Verihash message hasher.
 ///
@@ -61,7 +60,8 @@ where
     ) -> Result<(), Error> {
         match self.state {
             Some(State::Message { remaining }) if remaining == 0 => {
-                hash_fixed(&mut self.digest, tag, WireType::Message, digest);
+                hash_tag(&mut self.digest, tag);
+                hash_fixed(&mut self.digest, WireType::Message, digest);
                 self.state = Some(State::Initial);
                 Ok(())
             }
@@ -180,7 +180,8 @@ impl State {
                 _ => unreachable!(),
             };
 
-            hash_dynamically_sized_value(digest, header.tag, wire_type, length);
+            hash_tag(digest, header.tag);
+            hash_dynamically_sized_value(digest, wire_type, length);
 
             Ok(new_state)
         } else {
@@ -294,46 +295,4 @@ impl State {
             Err(Error::Hashing)
         }
     }
-}
-
-/// Hash a boolean
-pub fn hash_boolean<D: Digest>(digest: &mut D, tag: Tag, value: bool) {
-    let (wire_type, body) = if value {
-        (WireType::True, b"\x01")
-    } else {
-        (WireType::False, b"\x00")
-    };
-
-    hash_fixed(digest, tag, wire_type, body);
-}
-
-/// Hash an unsigned integer
-pub fn hash_uint64<D: Digest>(digest: &mut D, tag: Tag, value: u64) {
-    hash_fixed(digest, tag, WireType::UInt64, &value.to_le_bytes());
-}
-
-/// Hash a signed integer
-pub fn hash_sint64<D: Digest>(digest: &mut D, tag: Tag, value: i64) {
-    hash_fixed(digest, tag, WireType::SInt64, &value.to_le_bytes());
-}
-
-/// Hash bytes
-pub fn hash_dynamically_sized_value<D: Digest>(
-    digest: &mut D,
-    tag: Tag,
-    wire_type: WireType,
-    length: usize,
-) {
-    digest.input(&[TAG_PREFIX]);
-    digest.input(&tag.to_le_bytes());
-    digest.input(&[wire_type.to_u8()]);
-    digest.input(&(length as u64).to_le_bytes());
-}
-
-/// Hash a fixed-width value with the given wiretype
-fn hash_fixed<D: Digest>(digest: &mut D, tag: Tag, wire_type: WireType, body: &[u8]) {
-    digest.input(&[TAG_PREFIX]);
-    digest.input(&tag.to_le_bytes());
-    digest.input(&[wire_type.to_u8()]);
-    digest.input(body);
 }

--- a/rust/src/decoder/sequence.rs
+++ b/rust/src/decoder/sequence.rs
@@ -1,6 +1,7 @@
 //! Sequence decoder
 
 mod decoder;
+mod hasher;
 mod iter;
 mod state;
 

--- a/rust/src/decoder/sequence/hasher.rs
+++ b/rust/src/decoder/sequence/hasher.rs
@@ -1,0 +1,203 @@
+//! Verihash sequence hasher.
+//!
+//! WARNING: this is an experimental PoC-quality implementation!
+//! It is NOT suitable for production use!
+
+// TODO(tarcieri): tests and test vectors!!!
+// TODO(tarcieri): DRY out repeated logic in sequence hasher
+
+use crate::{decoder::Event, error::Error, field::WireType, verihash::*};
+use core::fmt::{self, Debug};
+use digest::Digest;
+
+/// Verihash sequence hasher.
+///
+/// This type computes a hash-based transcript of how a message was
+/// decoded, driven by incoming decoding events.
+pub struct Hasher<D: Digest> {
+    /// Computed digest in-progress
+    digest: D,
+
+    /// Current state of the decoder (or `None` if an error occurred)
+    state: Option<State>,
+}
+
+impl<D> Hasher<D>
+where
+    D: Digest,
+{
+    /// Create a new [`Hasher`]
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Hash an incoming event
+    pub fn hash_event(&mut self, event: &Event<'_>) -> Result<(), Error> {
+        if let Some(state) = self.state.take() {
+            let new_state = state.transition(event, &mut self.digest)?;
+            self.state = Some(new_state);
+            Ok(())
+        } else {
+            Err(Error::Failed)
+        }
+    }
+}
+
+impl<D> Default for Hasher<D>
+where
+    D: Digest,
+{
+    fn default() -> Self {
+        Self {
+            digest: D::new(),
+            state: Some(State::default()),
+        }
+    }
+}
+
+impl<D> Debug for Hasher<D>
+where
+    D: Digest,
+{
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("Hasher").finish()
+    }
+}
+
+#[derive(Debug, Eq, PartialEq)]
+enum State {
+    /// At the start of a message with no data processed
+    Initial,
+
+    /// Hashing a bytes field
+    Bytes { remaining: usize },
+
+    /// Hashing a string field
+    String { remaining: usize },
+
+    /// Hashing a message value
+    Message { remaining: usize },
+}
+
+impl Default for State {
+    fn default() -> Self {
+        State::Initial
+    }
+}
+
+impl State {
+    /// Transition to a new state based on an incoming event or return an error
+    pub fn transition<D: Digest>(self, event: &Event<'_>, digest: &mut D) -> Result<Self, Error> {
+        match event {
+            Event::LengthDelimiter { wire_type, length } => {
+                self.handle_length_delimiter(*wire_type, *length, digest)
+            }
+            Event::UInt64(_) | Event::SInt64(_) => self.handle_fixed_sized_value(event, digest),
+            Event::ValueChunk {
+                wire_type,
+                bytes,
+                remaining,
+            } => self.handle_value_chunk(*wire_type, bytes, *remaining, digest),
+            _ => Err(Error::Hashing),
+        }
+    }
+
+    /// Handle length delimiter event
+    fn handle_length_delimiter<D: Digest>(
+        self,
+        wire_type: WireType,
+        length: usize,
+        digest: &mut D,
+    ) -> Result<Self, Error> {
+        if self != State::Initial {
+            return Err(Error::Hashing);
+        }
+
+        let new_state = match wire_type {
+            WireType::Bytes => State::Bytes { remaining: length },
+            WireType::String => State::String { remaining: length },
+            WireType::Message => State::Message { remaining: length },
+            _ => unreachable!(),
+        };
+
+        hash_dynamically_sized_value(digest, wire_type, length);
+        Ok(new_state)
+    }
+
+    /// Handle hashing an incoming fixed-width value
+    fn handle_fixed_sized_value<D: Digest>(
+        self,
+        value: &Event<'_>,
+        digest: &mut D,
+    ) -> Result<Self, Error> {
+        if self != State::Initial {
+            return Err(Error::Hashing);
+        }
+
+        match value {
+            Event::UInt64(value) => hash_fixed(digest, WireType::UInt64, &value.to_le_bytes()),
+            Event::SInt64(value) => hash_fixed(digest, WireType::SInt64, &value.to_le_bytes()),
+            _ => unreachable!(),
+        }
+        Ok(State::Initial)
+    }
+
+    /// Handle an incoming chunk of data in a value
+    fn handle_value_chunk<D: Digest>(
+        self,
+        wire_type: WireType,
+        bytes: &[u8],
+        new_remaining: usize,
+        digest: &mut D,
+    ) -> Result<Self, Error> {
+        // TODO(tarcieri): DRY this out (especially with the message decoder)
+        let new_state = match self {
+            State::Bytes { remaining } => {
+                if wire_type != WireType::Bytes || remaining - bytes.len() != new_remaining {
+                    return Err(Error::Hashing);
+                }
+
+                if new_remaining == 0 {
+                    State::Initial
+                } else {
+                    State::Bytes {
+                        remaining: new_remaining,
+                    }
+                }
+            }
+            State::String { remaining } => {
+                // TODO(tarcieri): use `unicode-normalization`?
+
+                if wire_type != WireType::String || remaining - bytes.len() != new_remaining {
+                    return Err(Error::Hashing);
+                }
+
+                if new_remaining == 0 {
+                    State::Initial
+                } else {
+                    State::String {
+                        remaining: new_remaining,
+                    }
+                }
+            }
+            State::Message { remaining } => {
+                if wire_type != WireType::Message || remaining - bytes.len() != new_remaining {
+                    return Err(Error::Hashing);
+                }
+
+                // TODO(tarcieri): handle nested message digests in sequences
+                if new_remaining == 0 {
+                    return Ok(State::Initial);
+                } else {
+                    return Ok(State::Message {
+                        remaining: new_remaining,
+                    });
+                }
+            }
+            _ => return Err(Error::Hashing),
+        };
+
+        digest.input(bytes);
+        Ok(new_state)
+    }
+}

--- a/rust/src/decoder/traits.rs
+++ b/rust/src/decoder/traits.rs
@@ -6,6 +6,7 @@
 
 use super::sequence;
 use crate::{error::Error, field::Tag};
+use digest::Digest;
 
 /// Try to decode a field to a value of the given type.
 ///
@@ -26,11 +27,14 @@ pub trait DecodeRef<T: ?Sized> {
 /// Decode a sequence of values to a [`sequence::Iter`].
 ///
 /// This trait is intended to be impl'd by the [`Decoder`] type.
-pub trait DecodeSeq<T> {
+pub trait DecodeSeq<T, D>
+where
+    D: Digest,
+{
     /// Try to decode a sequence of values of type `T`
     fn decode_seq<'a>(
         &mut self,
         tag: Tag,
         input: &mut &'a [u8],
-    ) -> Result<sequence::Iter<'a, T>, Error>;
+    ) -> Result<sequence::Iter<'a, T, D>, Error>;
 }

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -23,6 +23,7 @@ pub mod encoder;
 pub mod error;
 pub mod field;
 pub mod message;
+mod verihash;
 
 // Re-export the `digest` crate
 pub use digest;

--- a/rust/src/verihash.rs
+++ b/rust/src/verihash.rs
@@ -1,0 +1,51 @@
+//! Verihash core hashing primitives
+
+use crate::field::{Tag, WireType};
+use digest::Digest;
+
+/// Verihash prefix used by tags (unsigned integer)
+// TODO(tarcieri): support string tags?
+const TAG_PREFIX: u8 = WireType::UInt64.to_u8();
+
+/// Hash a boolean
+pub fn hash_boolean<D: Digest>(digest: &mut D, tag: Tag, value: bool) {
+    let (wire_type, body) = if value {
+        (WireType::True, b"\x01")
+    } else {
+        (WireType::False, b"\x00")
+    };
+
+    hash_tag(digest, tag);
+    hash_fixed(digest, wire_type, body);
+}
+
+/// Hash an unsigned integer
+pub fn hash_uint64<D: Digest>(digest: &mut D, tag: Tag, value: u64) {
+    hash_tag(digest, tag);
+    hash_fixed(digest, WireType::UInt64, &value.to_le_bytes());
+}
+
+/// Hash a signed integer
+pub fn hash_sint64<D: Digest>(digest: &mut D, tag: Tag, value: i64) {
+    hash_tag(digest, tag);
+    hash_fixed(digest, WireType::SInt64, &value.to_le_bytes());
+}
+
+/// Hash a numerical tag
+// TODO(tarcieri): support string tags?
+pub fn hash_tag<D: Digest>(digest: &mut D, tag: Tag) {
+    digest.input(&[TAG_PREFIX]);
+    digest.input(&tag.to_le_bytes());
+}
+
+/// Hash a dynamically sized value
+pub fn hash_dynamically_sized_value<D: Digest>(digest: &mut D, wire_type: WireType, length: usize) {
+    digest.input(&[wire_type.to_u8()]);
+    digest.input(&(length as u64).to_le_bytes());
+}
+
+/// Hash an untagged value
+pub fn hash_fixed<D: Digest>(digest: &mut D, wire_type: WireType, body: &[u8]) {
+    digest.input(&[wire_type.to_u8()]);
+    digest.input(body);
+}


### PR DESCRIPTION
This adds partial support for computing Verihash over sequences.

It's still riddled with TODOs and does not yet extract the resulting digest of sequences and add it to the messages (or other sequences) that contain them.

However, it does fully parameterize the sequence decoder with the digest type, adds an initial `sequence::Hasher`, and lays the groundwork for eventually committing to these hashes.

I'm committing it anyway despite its incomplete state because I'd like to do some refactoring on Verihash computation before completing this work and wanted to break it down into incremental steps (so expect a "part 3" which completes the implementation)