### PR TITLE
rust: error type refactoring

### DIFF
--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -30,3 +30,4 @@ std = ["alloc"]
 
 [package.metadata.docs.rs]
 all-features = true
+rustdoc-args = ["--cfg", "docsrs"]

--- a/rust/src/builtins/timestamp.rs
+++ b/rust/src/builtins/timestamp.rs
@@ -14,7 +14,8 @@ pub use tai64::TAI64N as Timestamp;
 use crate::{
     decoder::{Decode, Decoder},
     digest::Digest,
-    field, Encoder, Error, Message,
+    error::{self, Error},
+    field, Encoder, Message,
 };
 use core::convert::TryInto;
 
@@ -27,13 +28,13 @@ impl Message for Timestamp {
         let nanos: u64 = decoder.decode(1, &mut input)?;
 
         if nanos > core::u32::MAX as u64 {
-            return Err(Error::Length);
+            return Err(error::Kind::Length.into());
         }
 
         let mut bytes = [0u8; 12];
         bytes[..8].copy_from_slice(&secs.to_le_bytes());
         bytes[8..].copy_from_slice(&(nanos as u32).to_le_bytes());
-        bytes.try_into().map_err(|_| Error::Builtin)
+        bytes.try_into().map_err(|_| error::Kind::Builtin.into())
     }
 
     fn encode<'a>(&self, buffer: &'a mut [u8]) -> Result<&'a [u8], Error> {

--- a/rust/src/builtins/uuid.rs
+++ b/rust/src/builtins/uuid.rs
@@ -13,7 +13,8 @@ pub use uuid::Uuid;
 use crate::{
     decoder::{DecodeRef, Decoder},
     digest::Digest,
-    field, Encoder, Error, Message,
+    error::{self, Error},
+    field, Encoder, Message,
 };
 use core::convert::TryInto;
 
@@ -27,7 +28,7 @@ impl Message for Uuid {
         bytes
             .try_into()
             .map(Uuid::from_bytes)
-            .map_err(|_| Error::Builtin)
+            .map_err(|_| error::Kind::Builtin.into())
     }
 
     fn encode<'a>(&self, buffer: &'a mut [u8]) -> Result<&'a [u8], Error> {

--- a/rust/src/decoder.rs
+++ b/rust/src/decoder.rs
@@ -19,8 +19,9 @@ pub use self::{
 };
 
 use crate::{
+    error::{self, Error},
     field::{Tag, WireType},
-    Error, Message,
+    Message,
 };
 use digest::{generic_array::GenericArray, Digest};
 use heapless::consts::U16;
@@ -56,7 +57,7 @@ where
     pub fn push(&mut self) -> Result<(), Error> {
         self.stack
             .push(message::Decoder::new())
-            .map_err(|_| Error::NestingDepth)
+            .map_err(|_| error::Kind::NestingDepth.into())
     }
 
     /// Pop the message decoder from the stack when we've finished a message.

--- a/rust/src/decoder/message/body.rs
+++ b/rust/src/decoder/message/body.rs
@@ -1,7 +1,7 @@
 //! Decoder for the bodies of variable-length field values
 
 use super::state::State;
-use crate::{decoder::Event, error::Error, field::WireType};
+use crate::{decoder::Event, error::Kind, field::WireType};
 
 /// Decoder for the bodies of variable-length field values
 #[derive(Debug)]
@@ -32,7 +32,7 @@ impl Decoder {
 
     /// Process the given input data, advancing the slice for the amount of
     /// data processed, and returning the new state.
-    pub fn decode<'a>(self, input: &mut &'a [u8]) -> Result<(State, Option<Event<'a>>), Error> {
+    pub fn decode<'a>(self, input: &mut &'a [u8]) -> Result<(State, Option<Event<'a>>), Kind> {
         if input.is_empty() {
             return Ok((self.into(), None));
         }

--- a/rust/src/decoder/message/header.rs
+++ b/rust/src/decoder/message/header.rs
@@ -3,7 +3,7 @@
 use super::state::State;
 use crate::{
     decoder::{vint64, Event},
-    error::Error,
+    error::Kind,
     field::{Header, Tag},
 };
 
@@ -18,14 +18,14 @@ impl Decoder {
         mut self,
         input: &mut &'a [u8],
         last_tag: Option<Tag>,
-    ) -> Result<(State, Option<Event<'a>>), Error> {
+    ) -> Result<(State, Option<Event<'a>>), Kind> {
         if let Some(value) = self.0.decode(input)? {
             let header = Header::from(value);
 
             // Ensure field ordering is monotonically increasing
             if let Some(tag) = last_tag {
                 if header.tag <= tag {
-                    return Err(Error::Order { tag: header.tag });
+                    return Err(Kind::Order { tag: header.tag });
                 }
             }
 

--- a/rust/src/decoder/message/state.rs
+++ b/rust/src/decoder/message/state.rs
@@ -3,7 +3,7 @@
 use super::{body, header, value};
 use crate::{
     decoder::Event,
-    error::Error,
+    error::Kind,
     field::{Tag, WireType},
 };
 
@@ -27,7 +27,7 @@ impl State {
         self,
         input: &mut &'a [u8],
         last_tag: Option<Tag>,
-    ) -> Result<(Self, Option<Event<'a>>), Error> {
+    ) -> Result<(Self, Option<Event<'a>>), Kind> {
         match self {
             State::Header(header) => header.decode(input, last_tag),
             State::Value(value) => value.decode(input),

--- a/rust/src/decoder/message/value.rs
+++ b/rust/src/decoder/message/value.rs
@@ -6,7 +6,7 @@ use crate::{
         vint64::{self, zigzag},
         Event,
     },
-    error::Error,
+    error::Kind,
     field::WireType,
 };
 
@@ -31,7 +31,7 @@ impl Decoder {
 
     /// Process the given input data, advancing the slice for the amount of
     /// data processed, and returning the new state.
-    pub fn decode<'a>(mut self, input: &mut &'a [u8]) -> Result<(State, Option<Event<'a>>), Error> {
+    pub fn decode<'a>(mut self, input: &mut &'a [u8]) -> Result<(State, Option<Event<'a>>), Kind> {
         if let Some(value) = self.decoder.decode(input)? {
             let event = match self.wire_type {
                 WireType::False => Event::Bool(false),

--- a/rust/src/decoder/sequence/state.rs
+++ b/rust/src/decoder/sequence/state.rs
@@ -5,7 +5,7 @@ use crate::{
         vint64::{self, zigzag},
         Event,
     },
-    error::Error,
+    error::Kind,
     field::WireType,
     message::Element,
 };
@@ -38,7 +38,7 @@ impl State {
         &mut self,
         wire_type: WireType,
         input: &mut &'a [u8],
-    ) -> Result<Option<Event<'a>>, Error> {
+    ) -> Result<Option<Event<'a>>, Kind> {
         let event = match self {
             State::Value(decoder) => {
                 if let Some(value) = decoder.decode(input)? {
@@ -51,7 +51,7 @@ impl State {
                         },
                         WireType::False | WireType::True => {
                             // TODO(tarcieri): support boolean sequences?
-                            return Err(Error::Decode {
+                            return Err(Kind::Decode {
                                 element: Element::Value,
                                 wire_type,
                             });

--- a/rust/src/decoder/traits.rs
+++ b/rust/src/decoder/traits.rs
@@ -5,12 +5,12 @@
 //! They're intened to be impl'd by `veriform::decoder::Decoder`.
 
 use super::sequence;
-use crate::{error::Error, field::Tag};
+use crate::{field::Tag, Error};
 use digest::Digest;
 
 /// Try to decode a field to a value of the given type.
 ///
-/// This trait is intended to be impl'd by the [`Decoder`] type.
+/// This trait is intended to be impl'd by the `Decoder` type.
 pub trait Decode<T> {
     /// Try to decode a value of type `T`
     fn decode(&mut self, tag: Tag, input: &mut &[u8]) -> Result<T, Error>;
@@ -18,7 +18,7 @@ pub trait Decode<T> {
 
 /// Try to decode a field to a reference of the given type.
 ///
-/// This trait is intended to be impl'd by the [`Decoder`] type.
+/// This trait is intended to be impl'd by the `Decoder` type.
 pub trait DecodeRef<T: ?Sized> {
     /// Try to decode a reference to type `T`
     fn decode_ref<'a>(&mut self, tag: Tag, input: &mut &'a [u8]) -> Result<&'a T, Error>;
@@ -26,7 +26,7 @@ pub trait DecodeRef<T: ?Sized> {
 
 /// Decode a sequence of values to a [`sequence::Iter`].
 ///
-/// This trait is intended to be impl'd by the [`Decoder`] type.
+/// This trait is intended to be impl'd by the `Decoder` type.
 pub trait DecodeSeq<T, D>
 where
     D: Digest,

--- a/rust/src/decoder/vint64.rs
+++ b/rust/src/decoder/vint64.rs
@@ -2,7 +2,7 @@
 
 pub(crate) use vint64::signed::zigzag;
 
-use crate::error::Error;
+use crate::error::Kind;
 
 /// Decoder for `vint64` values
 #[derive(Clone, Debug, Default)]
@@ -24,7 +24,7 @@ impl Decoder {
     }
 
     /// Decode a `vint64` from the incoming data
-    pub fn decode(&mut self, input: &mut &[u8]) -> Result<Option<u64>, Error> {
+    pub fn decode(&mut self, input: &mut &[u8]) -> Result<Option<u64>, Kind> {
         if let Some(length) = self.length {
             self.fill_buffer(length, input);
             return self.maybe_decode(length);
@@ -55,7 +55,7 @@ impl Decoder {
     }
 
     /// Attempt to decode the internal buffer if we've read its full contents
-    fn maybe_decode(&self, length: usize) -> Result<Option<u64>, Error> {
+    fn maybe_decode(&self, length: usize) -> Result<Option<u64>, Kind> {
         if self.pos < length {
             return Ok(None);
         }
@@ -63,6 +63,6 @@ impl Decoder {
         let mut buffer = &self.buffer[..length];
         vint64::decode(&mut buffer)
             .map(Some)
-            .map_err(|_| Error::VInt64)
+            .map_err(|_| Kind::VInt64)
     }
 }

--- a/rust/src/encoder.rs
+++ b/rust/src/encoder.rs
@@ -1,7 +1,7 @@
 //! Veriform encoder
 
 use crate::{
-    error::Error,
+    error::{self, Error},
     field::{Header, Tag, WireType},
     message::Message,
 };
@@ -47,7 +47,7 @@ impl<'a> Encoder<'a> {
 
         // Ensure there's remaining space in the buffer
         if encoded_len > (self.buffer.len() - self.length) {
-            return Err(Error::Length);
+            return Err(error::Kind::Length.into());
         }
 
         let new_length = self.length.checked_add(encoded_len).unwrap();
@@ -80,7 +80,7 @@ impl<'a> Encoder<'a> {
 
             // Ensure there's remaining space in the buffer
             if encoded_len > self.buffer.len().checked_sub(self.length).unwrap() {
-                return Err(Error::Length);
+                return Err(error::Kind::Length.into());
             }
 
             let new_length = self.length.checked_add(encoded_len).unwrap();
@@ -130,7 +130,7 @@ impl<'a> Encoder<'a> {
 
         // Ensure there's remaining space in the buffer
         if bytes.len() > (self.buffer.len() - self.length) {
-            return Err(Error::Length);
+            return Err(error::Kind::Length.into());
         }
 
         let new_length = self.length.checked_add(bytes.len()).unwrap();

--- a/rust/src/error.rs
+++ b/rust/src/error.rs
@@ -1,14 +1,68 @@
-//! Error type
+//! Error types
 
 use crate::{
     field::{Tag, WireType},
     message::Element,
 };
+use core::fmt::{self, Display};
 use displaydoc::Display;
 
 /// Error type
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+pub struct Error {
+    /// Kind of error
+    kind: Kind,
+
+    /// Position inside of message where error occurred
+    position: Option<usize>,
+}
+
+impl Error {
+    /// Get the [`Kind`] of error that occurred
+    pub fn kind(self) -> Kind {
+        self.kind
+    }
+
+    /// Get the position inside of the message where the error occurred
+    /// (if available)
+    ///
+    /// NOTE: support for this is an unreliable work-in-progress. Most of the
+    /// time this will return `None`.
+    pub fn position(self) -> Option<usize> {
+        self.position
+    }
+
+    /// Extend the position within a message (for nested messages)
+    // TODO(tarcieri): remove `#[allow(dead_code)]` attrs once this method is used
+    #[allow(dead_code)]
+    pub(crate) fn extend_position(self, pos: usize) -> Self {
+        let new_position = self.position.map(|old_pos| old_pos + pos).unwrap_or(pos);
+
+        Self {
+            kind: self.kind,
+            position: Some(new_position),
+        }
+    }
+}
+
+impl Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.kind)?;
+
+        if let Some(pos) = self.position {
+            write!(f, " position={}", pos)?;
+        }
+
+        Ok(())
+    }
+}
+
+#[cfg(feature = "std")]
+impl std::error::Error for Error {}
+
+/// Kinds of errors
 #[derive(Copy, Clone, Debug, Display, Eq, PartialEq)]
-pub enum Error {
+pub enum Kind {
     /// error decoding builtin type
     Builtin,
 
@@ -83,5 +137,21 @@ pub enum Error {
     VInt64,
 }
 
-#[cfg(feature = "std")]
-impl std::error::Error for Error {}
+impl Kind {
+    /// Create an error with the given position
+    pub(crate) fn position(self, pos: usize) -> Error {
+        Error {
+            kind: self,
+            position: Some(pos),
+        }
+    }
+}
+
+impl From<Kind> for Error {
+    fn from(kind: Kind) -> Self {
+        Self {
+            kind,
+            position: None,
+        }
+    }
+}

--- a/rust/src/field/wire_type.rs
+++ b/rust/src/field/wire_type.rs
@@ -1,6 +1,6 @@
 //! Veriform wire types
 
-pub use crate::error::Error;
+pub use crate::error::Kind;
 use core::convert::TryFrom;
 
 /// Wire type identifiers for Veriform types
@@ -54,9 +54,9 @@ impl WireType {
 }
 
 impl TryFrom<u64> for WireType {
-    type Error = Error;
+    type Error = Kind;
 
-    fn try_from(encoded: u64) -> Result<Self, Error> {
+    fn try_from(encoded: u64) -> Result<Self, Kind> {
         match encoded {
             0 => Ok(WireType::False),
             1 => Ok(WireType::True),
@@ -66,7 +66,7 @@ impl TryFrom<u64> for WireType {
             5 => Ok(WireType::String),
             6 => Ok(WireType::Message),
             7 => Ok(WireType::Sequence),
-            _ => Err(Error::InvalidWireType),
+            _ => Err(Kind::InvalidWireType),
         }
     }
 }

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -5,6 +5,7 @@
 //! with a zero-copy pull parser.
 
 #![no_std]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 #![doc(html_root_url = "https://docs.rs/veriform/0.0.1")]
 #![forbid(unsafe_code)]
 #![warn(missing_docs, rust_2018_idioms, unused_qualifications)]
@@ -35,4 +36,5 @@ pub use crate::{encoder::Encoder, error::Error, message::Message};
 
 /// Veriform decoder with the default SHA-256 hash
 #[cfg(feature = "sha2")]
+#[cfg_attr(docsrs, doc(cfg(feature = "sha2")))]
 pub type Decoder = crate::decoder::Decoder<sha2::Sha256>;


### PR DESCRIPTION
Renames the enum `error::Error` => `error::Kind`.

Adds a new `error::Error` struct which wraps an `error::Kind` and also carries with it an optional position within a message where an error occurred.