### PR TITLE
rust: support caching computed Verihash message digests

### DIFF
--- a/rust/src/decoder/message/hasher.rs
+++ b/rust/src/decoder/message/hasher.rs
@@ -13,7 +13,7 @@
 
 use crate::{
     decoder::Event,
-    error::Kind,
+    error::{self, Error},
     field::{self, Tag, WireType},
     verihash,
 };
@@ -45,13 +45,13 @@ where
     }
 
     /// Hash an incoming event
-    pub fn hash_event(&mut self, event: &Event<'_>) -> Result<(), Kind> {
+    pub fn hash_event(&mut self, event: &Event<'_>) -> Result<(), Error> {
         if let Some(state) = self.state.take() {
             let new_state = state.transition(event, &mut self.verihash)?;
             self.state = Some(new_state);
             Ok(())
         } else {
-            Err(Kind::Failed)
+            Err(error::Kind::Failed.into())
         }
     }
 
@@ -60,7 +60,7 @@ where
         &mut self,
         tag: Tag,
         digest: &GenericArray<u8, D::OutputSize>,
-    ) -> Result<(), Kind> {
+    ) -> Result<(), Error> {
         match self.state {
             Some(State::Message { remaining }) if remaining == 0 => {
                 self.verihash.tag(tag);
@@ -68,16 +68,16 @@ where
                 self.state = Some(State::Initial);
                 Ok(())
             }
-            _ => Err(Kind::Hashing),
+            _ => Err(error::Kind::Hashing.into()),
         }
     }
 
     /// Finish computing digest
-    pub fn finish(self) -> Result<GenericArray<u8, D::OutputSize>, Kind> {
+    pub fn finish(self) -> Result<GenericArray<u8, D::OutputSize>, Error> {
         if self.state == Some(State::Initial) {
             Ok(self.verihash.finish())
         } else {
-            Err(Kind::Hashing)
+            Err(error::Kind::Hashing.into())
         }
     }
 }
@@ -136,7 +136,7 @@ impl State {
         self,
         event: &Event<'_>,
         verihash: &mut verihash::Hasher<D>,
-    ) -> Result<Self, Kind> {
+    ) -> Result<Self, Error> {
         match event {
             Event::FieldHeader(header) => self.handle_field_header(header),
             Event::LengthDelimiter { wire_type, length } => {
@@ -157,11 +157,11 @@ impl State {
     }
 
     /// Handle an incoming field header
-    fn handle_field_header(self, header: &field::Header) -> Result<Self, Kind> {
+    fn handle_field_header(self, header: &field::Header) -> Result<Self, Error> {
         if self == State::Initial {
             Ok(State::Header(*header))
         } else {
-            Err(Kind::Hashing)
+            Err(error::Kind::Hashing.into())
         }
     }
 
@@ -171,10 +171,10 @@ impl State {
         wire_type: WireType,
         length: usize,
         verihash: &mut verihash::Hasher<D>,
-    ) -> Result<Self, Kind> {
+    ) -> Result<Self, Error> {
         if let State::Header(header) = self {
             if wire_type != header.wire_type {
-                return Err(Kind::Hashing);
+                return Err(error::Kind::Hashing.into());
             }
 
             let new_state = match wire_type {
@@ -189,7 +189,7 @@ impl State {
 
             Ok(new_state)
         } else {
-            Err(Kind::Hashing)
+            Err(error::Kind::Hashing.into())
         }
     }
 
@@ -198,7 +198,7 @@ impl State {
         self,
         value: &Event<'_>,
         verihash: &mut verihash::Hasher<D>,
-    ) -> Result<Self, Kind> {
+    ) -> Result<Self, Error> {
         if let State::Header(header) = self {
             match value {
                 Event::Bool(value) => verihash.tagged_boolean(header.tag, *value),
@@ -207,7 +207,7 @@ impl State {
                 _ => unreachable!(),
             }
         } else {
-            return Err(Kind::Hashing);
+            return Err(error::Kind::Hashing.into());
         }
 
         Ok(State::Initial)
@@ -220,12 +220,12 @@ impl State {
         bytes: &[u8],
         new_remaining: usize,
         verihash: &mut verihash::Hasher<D>,
-    ) -> Result<Self, Kind> {
+    ) -> Result<Self, Error> {
         // TODO(tarcieri): DRY this out
         let new_state = match self {
             State::Bytes { remaining } => {
                 if wire_type != WireType::Bytes || remaining - bytes.len() != new_remaining {
-                    return Err(Kind::Hashing);
+                    return Err(error::Kind::Hashing.into());
                 }
 
                 if new_remaining == 0 {
@@ -240,7 +240,7 @@ impl State {
                 // TODO(tarcieri): use `unicode-normalization`?
 
                 if wire_type != WireType::String || remaining - bytes.len() != new_remaining {
-                    return Err(Kind::Hashing);
+                    return Err(error::Kind::Hashing.into());
                 }
 
                 if new_remaining == 0 {
@@ -253,7 +253,7 @@ impl State {
             }
             State::Message { remaining } => {
                 if wire_type != WireType::Message || remaining - bytes.len() != new_remaining {
-                    return Err(Kind::Hashing);
+                    return Err(error::Kind::Hashing.into());
                 }
 
                 return Ok(State::Message {
@@ -265,7 +265,7 @@ impl State {
                 remaining,
             } => {
                 if wire_type != WireType::Sequence || remaining - bytes.len() != new_remaining {
-                    return Err(Kind::Hashing);
+                    return Err(error::Kind::Hashing.into());
                 } else if new_remaining == 0 {
                     return Ok(State::Initial);
                 } else {
@@ -276,7 +276,7 @@ impl State {
                 }
             }
             _ => {
-                return Err(Kind::Hashing);
+                return Err(error::Kind::Hashing.into());
             }
         };
 
@@ -285,10 +285,10 @@ impl State {
     }
 
     /// Handle an incoming sequence header
-    fn handle_sequence_header(self, wire_type: WireType, length: usize) -> Result<Self, Kind> {
+    fn handle_sequence_header(self, wire_type: WireType, length: usize) -> Result<Self, Error> {
         if let State::Header(header) = self {
             if header.wire_type != WireType::Sequence {
-                return Err(Kind::Hashing);
+                return Err(error::Kind::Hashing.into());
             }
 
             Ok(State::Sequence {
@@ -296,7 +296,7 @@ impl State {
                 remaining: length,
             })
         } else {
-            Err(Kind::Hashing)
+            Err(error::Kind::Hashing.into())
         }
     }
 }

--- a/rust/src/decoder/sequence/hasher.rs
+++ b/rust/src/decoder/sequence/hasher.rs
@@ -6,7 +6,12 @@
 // TODO(tarcieri): tests and test vectors!!!
 // TODO(tarcieri): DRY out repeated message/sequence code into `verihash::Hasher`
 
-use crate::{decoder::Event, error::Kind, field::WireType, verihash};
+use crate::{
+    decoder::Event,
+    error::{self, Error},
+    field::WireType,
+    verihash,
+};
 use core::fmt::{self, Debug};
 use digest::Digest;
 
@@ -35,13 +40,13 @@ where
     }
 
     /// Hash an incoming event
-    pub fn hash_event(&mut self, event: &Event<'_>) -> Result<(), Kind> {
+    pub fn hash_event(&mut self, event: &Event<'_>) -> Result<(), Error> {
         if let Some(state) = self.state.take() {
             let new_state = state.transition(event, &mut self.verihash)?;
             self.state = Some(new_state);
             Ok(())
         } else {
-            Err(Kind::Failed)
+            Err(error::Kind::Failed.into())
         }
     }
 }
@@ -91,7 +96,7 @@ impl State {
         self,
         event: &Event<'_>,
         verihash: &mut verihash::Hasher<D>,
-    ) -> Result<Self, Kind> {
+    ) -> Result<Self, Error> {
         match event {
             Event::LengthDelimiter { wire_type, length } => {
                 self.handle_length_delimiter(*wire_type, *length, verihash)
@@ -102,7 +107,7 @@ impl State {
                 bytes,
                 remaining,
             } => self.handle_value_chunk(*wire_type, bytes, *remaining, verihash),
-            _ => Err(Kind::Hashing),
+            _ => Err(error::Kind::Hashing.into()),
         }
     }
 
@@ -112,9 +117,9 @@ impl State {
         wire_type: WireType,
         length: usize,
         verihash: &mut verihash::Hasher<D>,
-    ) -> Result<Self, Kind> {
+    ) -> Result<Self, Error> {
         if self != State::Initial {
-            return Err(Kind::Hashing);
+            return Err(error::Kind::Hashing.into());
         }
 
         let new_state = match wire_type {
@@ -133,9 +138,9 @@ impl State {
         self,
         value: &Event<'_>,
         verihash: &mut verihash::Hasher<D>,
-    ) -> Result<Self, Kind> {
+    ) -> Result<Self, Error> {
         if self != State::Initial {
-            return Err(Kind::Hashing);
+            return Err(error::Kind::Hashing.into());
         }
 
         match value {
@@ -157,12 +162,12 @@ impl State {
         bytes: &[u8],
         new_remaining: usize,
         verihash: &mut verihash::Hasher<D>,
-    ) -> Result<Self, Kind> {
+    ) -> Result<Self, Error> {
         // TODO(tarcieri): DRY this out (especially with the message decoder)
         let new_state = match self {
             State::Bytes { remaining } => {
                 if wire_type != WireType::Bytes || remaining - bytes.len() != new_remaining {
-                    return Err(Kind::Hashing);
+                    return Err(error::Kind::Hashing.into());
                 }
 
                 if new_remaining == 0 {
@@ -177,7 +182,7 @@ impl State {
                 // TODO(tarcieri): use `unicode-normalization`?
 
                 if wire_type != WireType::String || remaining - bytes.len() != new_remaining {
-                    return Err(Kind::Hashing);
+                    return Err(error::Kind::Hashing.into());
                 }
 
                 if new_remaining == 0 {
@@ -190,7 +195,7 @@ impl State {
             }
             State::Message { remaining } => {
                 if wire_type != WireType::Message || remaining - bytes.len() != new_remaining {
-                    return Err(Kind::Hashing);
+                    return Err(error::Kind::Hashing.into());
                 }
 
                 // TODO(tarcieri): handle nested message digests in sequences
@@ -202,7 +207,7 @@ impl State {
                     });
                 }
             }
-            _ => return Err(Kind::Hashing),
+            _ => return Err(error::Kind::Hashing.into()),
         };
 
         verihash.input(bytes);


### PR DESCRIPTION
Previously the `message::Decoder::finish_digest` method had the nice property of consuming the decoder (and therefore the message hasher) upon completion of a message. This previously ensured messages are only digested once they have been fully processed by making any subsequent processing of the same message unrepresentable once the digest has been
computed.

Unfortunately, in order to embed the computed digest into a struct, we need to access it multiple times, so this commit changes the method name and signature to `compute_digest(&mut self)` in order to allow it to be accessed several times:

- Once to embed it in the message struct itself
- Once when including the digest of a nested message in the "Merkelized" Verihash computation of its parent

(more accesses than twice are presently allowed, but unnecessary)

With this commit, it's now possible to compute a digest of a message at decoding time and store the digest alongside the contents of a message in a struct.

This is, after all, the whole point: we can compute these digests for arbitrary parts of a message, allowing signers to sign subsections/nested messages, and include their signatures alongside the signed portion in the parent message.

This commit also adds a `fill_digest()` method on the public `Decoder` API which is a sort of hack for avoiding `GenericArray` and can be used inside a `Message` implementation to consume the digest and store it in a regular `[u8; _]`.

The intent is to effectively standardize on SHA-256 and always use a `[u8; 32]` for this value, with a `#[digest(sha256)]` annotation in a proc macro to request the hash.