### PR TITLE
rust: error handling cleanup

### DIFF
--- a/rust/src/decoder/message/body.rs
+++ b/rust/src/decoder/message/body.rs
@@ -1,7 +1,7 @@
 //! Decoder for the bodies of variable-length field values
 
 use super::state::State;
-use crate::{decoder::Event, error::Kind, field::WireType};
+use crate::{decoder::Event, error::Error, field::WireType};
 
 /// Decoder for the bodies of variable-length field values
 #[derive(Debug)]
@@ -32,7 +32,7 @@ impl Decoder {
 
     /// Process the given input data, advancing the slice for the amount of
     /// data processed, and returning the new state.
-    pub fn decode<'a>(self, input: &mut &'a [u8]) -> Result<(State, Option<Event<'a>>), Kind> {
+    pub fn decode<'a>(self, input: &mut &'a [u8]) -> Result<(State, Option<Event<'a>>), Error> {
         if input.is_empty() {
             return Ok((self.into(), None));
         }

--- a/rust/src/decoder/message/header.rs
+++ b/rust/src/decoder/message/header.rs
@@ -3,7 +3,7 @@
 use super::state::State;
 use crate::{
     decoder::{vint64, Event},
-    error::Kind,
+    error::{self, Error},
     field::{Header, Tag},
 };
 
@@ -18,14 +18,14 @@ impl Decoder {
         mut self,
         input: &mut &'a [u8],
         last_tag: Option<Tag>,
-    ) -> Result<(State, Option<Event<'a>>), Kind> {
+    ) -> Result<(State, Option<Event<'a>>), Error> {
         if let Some(value) = self.0.decode(input)? {
             let header = Header::from(value);
 
             // Ensure field ordering is monotonically increasing
             if let Some(tag) = last_tag {
                 if header.tag <= tag {
-                    return Err(Kind::Order { tag: header.tag });
+                    return Err(error::Kind::Order { tag: header.tag }.into());
                 }
             }
 

--- a/rust/src/decoder/message/state.rs
+++ b/rust/src/decoder/message/state.rs
@@ -3,7 +3,7 @@
 use super::{body, header, value};
 use crate::{
     decoder::Event,
-    error::Kind,
+    error::Error,
     field::{Tag, WireType},
 };
 
@@ -27,7 +27,7 @@ impl State {
         self,
         input: &mut &'a [u8],
         last_tag: Option<Tag>,
-    ) -> Result<(Self, Option<Event<'a>>), Kind> {
+    ) -> Result<(Self, Option<Event<'a>>), Error> {
         match self {
             State::Header(header) => header.decode(input, last_tag),
             State::Value(value) => value.decode(input),

--- a/rust/src/decoder/message/value.rs
+++ b/rust/src/decoder/message/value.rs
@@ -6,7 +6,7 @@ use crate::{
         vint64::{self, zigzag},
         Event,
     },
-    error::Kind,
+    error::Error,
     field::WireType,
 };
 
@@ -31,7 +31,7 @@ impl Decoder {
 
     /// Process the given input data, advancing the slice for the amount of
     /// data processed, and returning the new state.
-    pub fn decode<'a>(mut self, input: &mut &'a [u8]) -> Result<(State, Option<Event<'a>>), Kind> {
+    pub fn decode<'a>(mut self, input: &mut &'a [u8]) -> Result<(State, Option<Event<'a>>), Error> {
         if let Some(value) = self.decoder.decode(input)? {
             let event = match self.wire_type {
                 WireType::False => Event::Bool(false),

--- a/rust/src/decoder/sequence/state.rs
+++ b/rust/src/decoder/sequence/state.rs
@@ -5,7 +5,7 @@ use crate::{
         vint64::{self, zigzag},
         Event,
     },
-    error::Kind,
+    error::{self, Error},
     field::WireType,
     message::Element,
 };
@@ -38,7 +38,7 @@ impl State {
         &mut self,
         wire_type: WireType,
         input: &mut &'a [u8],
-    ) -> Result<Option<Event<'a>>, Kind> {
+    ) -> Result<Option<Event<'a>>, Error> {
         let event = match self {
             State::Value(decoder) => {
                 if let Some(value) = decoder.decode(input)? {
@@ -51,10 +51,11 @@ impl State {
                         },
                         WireType::False | WireType::True => {
                             // TODO(tarcieri): support boolean sequences?
-                            return Err(Kind::Decode {
+                            return Err(error::Kind::Decode {
                                 element: Element::Value,
                                 wire_type,
-                            });
+                            }
+                            .into());
                         }
                         wire_type => {
                             debug_assert!(

--- a/rust/src/decoder/vint64.rs
+++ b/rust/src/decoder/vint64.rs
@@ -2,7 +2,7 @@
 
 pub(crate) use vint64::signed::zigzag;
 
-use crate::error::Kind;
+use crate::error::{self, Error};
 
 /// Decoder for `vint64` values
 #[derive(Clone, Debug, Default)]
@@ -24,7 +24,7 @@ impl Decoder {
     }
 
     /// Decode a `vint64` from the incoming data
-    pub fn decode(&mut self, input: &mut &[u8]) -> Result<Option<u64>, Kind> {
+    pub fn decode(&mut self, input: &mut &[u8]) -> Result<Option<u64>, Error> {
         if let Some(length) = self.length {
             self.fill_buffer(length, input);
             return self.maybe_decode(length);
@@ -55,7 +55,7 @@ impl Decoder {
     }
 
     /// Attempt to decode the internal buffer if we've read its full contents
-    fn maybe_decode(&self, length: usize) -> Result<Option<u64>, Kind> {
+    fn maybe_decode(&self, length: usize) -> Result<Option<u64>, Error> {
         if self.pos < length {
             return Ok(None);
         }
@@ -63,6 +63,6 @@ impl Decoder {
         let mut buffer = &self.buffer[..length];
         vint64::decode(&mut buffer)
             .map(Some)
-            .map_err(|_| Kind::VInt64)
+            .map_err(|_| error::Kind::VInt64.into())
     }
 }

--- a/rust/src/field/wire_type.rs
+++ b/rust/src/field/wire_type.rs
@@ -1,6 +1,6 @@
 //! Veriform wire types
 
-pub use crate::error::Kind;
+pub use crate::error::{self, Error};
 use core::convert::TryFrom;
 
 /// Wire type identifiers for Veriform types
@@ -54,9 +54,9 @@ impl WireType {
 }
 
 impl TryFrom<u64> for WireType {
-    type Error = Kind;
+    type Error = Error;
 
-    fn try_from(encoded: u64) -> Result<Self, Kind> {
+    fn try_from(encoded: u64) -> Result<Self, Error> {
         match encoded {
             0 => Ok(WireType::False),
             1 => Ok(WireType::True),
@@ -66,7 +66,7 @@ impl TryFrom<u64> for WireType {
             5 => Ok(WireType::String),
             6 => Ok(WireType::Message),
             7 => Ok(WireType::Sequence),
-            _ => Err(Kind::InvalidWireType),
+            _ => Err(error::Kind::InvalidWireType.into()),
         }
     }
 }


### PR DESCRIPTION
Fix leftover `Result<_, Kind>` from #127