### PR TITLE
rust: initial custom derive support for sequences

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -90,9 +90,9 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.2.1"
+version = "3.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12ae9db68ad7fac5fe51304d20f016c911539251075a214f8e663babefa35187"
+checksum = "5356f1d23ee24a1f785a56d1d1a5f0fd5b0f6a0c0fb2412ce11da71649ab78f6"
 
 [[package]]
 name = "byte-tools"
@@ -323,9 +323,9 @@ checksum = "e88a8acf291dafb59c2d96e8f59828f3838bb1a70398823ade51a84de6a6deed"
 
 [[package]]
 name = "fnv"
-version = "1.0.6"
+version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2fad85553e09a6f881f739c29f0b00b0f01357c743266d478b68951ce23285f3"
+checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "fuchsia-cprng"
@@ -385,9 +385,9 @@ dependencies = [
 
 [[package]]
 name = "hermit-abi"
-version = "0.1.12"
+version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61565ff7aaace3525556587bd2dc31d4a07071957be715e63ce7b1eccf51a8f4"
+checksum = "91780f809e750b0a89f5544be56617ff6b1227ee485bcb06ebe10cdf89bd3b71"
 dependencies = [
  "libc",
 ]
@@ -430,9 +430,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.69"
+version = "0.2.70"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99e85c08494b21a9054e7fe1374a732aeadaff3980b6990b94bfd3a70f690005"
+checksum = "3baa92041a6fec78c687fa0cc2b3fae8884f743d672cf551bed1d6dac6988d0f"
 
 [[package]]
 name = "log"
@@ -509,15 +509,15 @@ dependencies = [
 
 [[package]]
 name = "ppv-lite86"
-version = "0.2.6"
+version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74490b50b9fbe561ac330df47c08f3f33073d2d00c150f719147d7c54522fa1b"
+checksum = "237a5ed80e274dbc66f86bd59c1e25edc039660be53194b5fe0a482e0f2612ea"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.12"
+version = "1.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8872cf6f48eee44265156c111456a700ab3483686b3f96df4cf5481c89157319"
+checksum = "53f5ffe53a6b28e37c9c1ce74893477864d64f74778a93a4beb43c8fa167f639"
 dependencies = [
  "unicode-xid",
 ]
@@ -550,9 +550,9 @@ checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 
 [[package]]
 name = "quote"
-version = "1.0.4"
+version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c1f4b0efa5fc5e8ceb705136bfee52cfdb6a4e3509f770b478cd6ed434232a7"
+checksum = "54a21852a652ad6f610c9510194f398ff6f8692e334fd1145fed931f7fbe44ea"
 dependencies = [
  "proc-macro2",
 ]
@@ -887,9 +887,9 @@ checksum = "6446ced80d6c486436db5c078dde11a9f73d42b57fb273121e160b84f63d894c"
 
 [[package]]
 name = "syn"
-version = "1.0.19"
+version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8e5aa70697bb26ee62214ae3288465ecec0000f05182f039b477001f08f5ae7"
+checksum = "1425de3c33b0941002740a420b1a906a350b88d08b82b2c8a01035a3f9447bac"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/rust/derive/src/field.rs
+++ b/rust/derive/src/field.rs
@@ -88,6 +88,7 @@ impl WireType {
             "bytes" => WireType::Bytes,
             "string" => WireType::String,
             "message" => WireType::Message,
+            "sequence" => WireType::Sequence,
             other => panic!("invalid wire type: {}", other),
         }
     }

--- a/rust/src/derive_helpers.rs
+++ b/rust/src/derive_helpers.rs
@@ -1,9 +1,15 @@
 //! Helper functions called from custom derive output
 
 use crate::{
+    decoder::sequence,
+    decoder::{DecodeSeq, Decoder},
+    encoder::Encoder,
     error::{self, Error},
-    field::Tag,
+    field::{Tag, WireType},
+    message::{Element, Message},
 };
+use digest::Digest;
+use heapless::ArrayLength;
 
 /// Make sure input has been consumed
 pub fn check_input_consumed(input: &[u8]) -> Result<(), Error> {
@@ -14,6 +20,60 @@ pub fn check_input_consumed(input: &[u8]) -> Result<(), Error> {
     }
 }
 
+/// Decode a sequence of messages
+// TODO(tarcieri): support other sequence types
+pub fn decode_message_seq<T, N, D>(
+    decoder: &mut Decoder<D>,
+    tag: Tag,
+    input: &mut &[u8],
+) -> Result<heapless::Vec<T, N>, Error>
+where
+    T: Message,
+    N: ArrayLength<T>,
+    D: Digest,
+{
+    let mut result = heapless::Vec::new();
+    let seq_iter: sequence::Iter<'_, T, D> = decoder.decode_seq(tag, input)?;
+
+    for elem in seq_iter {
+        result.push(elem?).map_err(|_| error::Kind::Decode {
+            element: Element::Value,
+            wire_type: WireType::Sequence,
+        })?
+    }
+
+    Ok(result)
+}
+
+/// Encode a sequence of messages
+pub fn encode_message_seq<T>(
+    encoder: &mut Encoder<'_>,
+    tag: Tag,
+    critical: bool,
+    seq: &[T],
+) -> Result<(), Error>
+where
+    T: Message,
+{
+    let body_len: usize = seq
+        .iter()
+        .map(|msg| {
+            // compute length with additional length prefix
+            let encoded_len = msg.encoded_len();
+            vint64::encoded_len(encoded_len as u64)
+                .checked_add(encoded_len)
+                .unwrap()
+        })
+        .sum();
+
+    encoder.message_seq(
+        tag,
+        critical,
+        body_len,
+        seq.iter().map(|elem| elem as &dyn Message),
+    )
+}
+
 /// Unknown tag in enum
 pub fn unknown_tag(tag: Tag) -> Error {
     error::Kind::FieldHeader {
@@ -21,4 +81,35 @@ pub fn unknown_tag(tag: Tag) -> Error {
         wire_type: None,
     }
     .into()
+}
+
+/// Fallible version of the `Extend` trait used for consuming Veriform
+/// sequences but with potential `max` limits (e.g. `heapless::Vec` size)
+pub trait TryExtend<A> {
+    /// Try to extend this type using the given iterator, returnin an error if
+    /// capacity in the underlying buffer is exceeded
+    fn try_extend<T>(&mut self, iter: T) -> Result<(), ()>
+    where
+        T: IntoIterator<Item = A>;
+}
+
+impl<T, N> TryExtend<T> for heapless::Vec<T, N>
+where
+    N: ArrayLength<T>,
+{
+    fn try_extend<I: IntoIterator<Item = T>>(&mut self, iter: I) -> Result<(), ()> {
+        for elem in iter {
+            self.push(elem).map_err(|_| ())?
+        }
+
+        Ok(())
+    }
+}
+
+#[cfg(feature = "alloc")]
+impl<T> TryExtend<T> for alloc::vec::Vec<T> {
+    fn try_extend<I: IntoIterator<Item = T>>(&mut self, iter: I) -> Result<(), ()> {
+        self.extend(iter);
+        Ok(())
+    }
 }

--- a/rust/tests/derive.rs
+++ b/rust/tests/derive.rs
@@ -1,6 +1,9 @@
 //! Integration tests for `veriform_derive`
 
-use heapless::{consts::U1024, Vec};
+use heapless::{
+    consts::{U1024, U8},
+    Vec,
+};
 use veriform::{Decoder, Message};
 
 /// Buffer type.
@@ -51,13 +54,23 @@ pub struct ExampleStruct {
 
     #[field(tag = 1, wire_type = "sint64", critical = true)]
     pub sint64_field: i64,
+
+    #[field(tag = 2, wire_type = "sequence", critical = true, max = 8)]
+    pub msg_sequence_field: heapless::Vec<ExampleEnum, U8>,
 }
 
 impl Default for ExampleStruct {
     fn default() -> Self {
+        let mut msg_sequence_field = heapless::Vec::new();
+
+        for _ in 0..3 {
+            msg_sequence_field.push(ExampleEnum::default()).unwrap();
+        }
+
         Self {
             uint64_field: 42,
             sint64_field: -42,
+            msg_sequence_field,
         }
     }
 }


### PR DESCRIPTION
The initial custom derive PR (#131) did not add support for fields containing sequences, and had `todo!()` instead.

This commit adds support for deriving `Message` on structs whose fields are sequences.

This support is limited to sequences of messages. A further PR is needed to generalize it over other wire types.