### PR TITLE
rust: use Option<digest> in custom derive

### DIFF
--- a/rust/derive/src/message.rs
+++ b/rust/derive/src/message.rs
@@ -346,13 +346,13 @@ impl DeriveStruct {
     /// Derive computing a SHA-256 digest of a message
     fn derive_sha256_digest(&mut self, name: &Ident) {
         let fill_digest = quote! {
-            let mut #name = [0u8; 32];
+            let mut #name = veriform::Sha256Digest::default();
             decoder.fill_digest(&mut #name)?;
         };
 
         fill_digest.to_tokens(&mut self.decode_body);
 
-        let inst_field = quote!(#name,);
+        let inst_field = quote!(#name: Some(#name),);
         inst_field.to_tokens(&mut self.inst_body);
     }
 }

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -42,6 +42,11 @@ pub use crate::{encoder::Encoder, error::Error, message::Message};
 #[cfg_attr(docsrs, doc(cfg(feature = "sha2")))]
 pub type Decoder = crate::decoder::Decoder<sha2::Sha256>;
 
+/// SHA-256 digests
+#[cfg(feature = "sha2")]
+#[cfg_attr(docsrs, doc(cfg(feature = "sha2")))]
+pub type Sha256Digest = [u8; 32];
+
 #[cfg(feature = "veriform_derive")]
 #[cfg_attr(docsrs, doc(cfg(feature = "veriform_derive")))]
 pub use veriform_derive::Message;

--- a/rust/tests/derive.rs
+++ b/rust/tests/derive.rs
@@ -59,7 +59,7 @@ pub struct ExampleStruct {
     pub msg_sequence_field: heapless::Vec<ExampleEnum, U8>,
 
     #[digest(alg = "sha256")]
-    pub digest: [u8; 32],
+    pub digest: Option<veriform::Sha256Digest>,
 }
 
 impl Default for ExampleStruct {
@@ -74,17 +74,14 @@ impl Default for ExampleStruct {
             uint64_field: 42,
             sint64_field: -42,
             msg_sequence_field,
-            digest: [
-                70, 253, 164, 73, 9, 251, 53, 54, 186, 12, 131, 51, 211, 21, 167, 39, 94, 115, 121,
-                247, 36, 223, 116, 164, 36, 154, 124, 156, 42, 115, 221, 197,
-            ],
+            digest: None,
         }
     }
 }
 
 #[test]
 fn struct_round_trip() {
-    let example = ExampleStruct::default();
+    let mut example = ExampleStruct::default();
 
     let mut encoded_buf = new_buffer();
     let encoded_len = example.encode(&mut encoded_buf).unwrap().len();
@@ -92,6 +89,13 @@ fn struct_round_trip() {
 
     let mut decoder = Decoder::new();
     let decoded = ExampleStruct::decode(&mut decoder, &encoded_buf).unwrap();
+
+    // Expected digest
+    // TODO(tarcieri): actually stabilize these!
+    example.digest = Some([
+        70, 253, 164, 73, 9, 251, 53, 54, 186, 12, 131, 51, 211, 21, 167, 39, 94, 115, 121, 247,
+        36, 223, 116, 164, 36, 154, 124, 156, 42, 115, 221, 197,
+    ]);
 
     assert_eq!(example, decoded);
 }


### PR DESCRIPTION
This avoids the need to specify a digest when a message is initially
crated, and only fills them in at the time a message is decoded.