### PR TITLE
rust: add type alias for DigestOutput

### DIFF
--- a/rust/src/decoder.rs
+++ b/rust/src/decoder.rs
@@ -21,9 +21,10 @@ pub use self::{
 use crate::{
     error::{self, Error},
     field::{Tag, WireType},
+    verihash::DigestOutput,
     Message,
 };
-use digest::{generic_array::GenericArray, Digest};
+use digest::Digest;
 use heapless::consts::U16;
 
 /// Veriform decoder
@@ -66,7 +67,7 @@ where
     ///
     /// Panics if the decoder's stack underflows.
     // TODO(tarcieri): panic-free higher-level API, possibly RAII-based?
-    pub fn pop(&mut self) -> Option<GenericArray<u8, D::OutputSize>> {
+    pub fn pop(&mut self) -> Option<DigestOutput<D>> {
         self.stack.pop().unwrap().compute_digest().unwrap()
     }
 

--- a/rust/src/decoder/message/hasher.rs
+++ b/rust/src/decoder/message/hasher.rs
@@ -15,10 +15,10 @@ use crate::{
     decoder::Event,
     error::{self, Error},
     field::{self, Tag, WireType},
-    verihash,
+    verihash::{self, DigestOutput},
 };
 use core::fmt::{self, Debug};
-use digest::{generic_array::GenericArray, Digest};
+use digest::Digest;
 
 /// Verihash message hasher.
 ///
@@ -56,11 +56,7 @@ where
     }
 
     /// Hash a digest of a nested message within this message
-    pub fn hash_message_digest(
-        &mut self,
-        tag: Tag,
-        digest: &GenericArray<u8, D::OutputSize>,
-    ) -> Result<(), Error> {
+    pub fn hash_message_digest(&mut self, tag: Tag, digest: &DigestOutput<D>) -> Result<(), Error> {
         match self.state {
             Some(State::Message { remaining }) if remaining == 0 => {
                 self.verihash.tag(tag);
@@ -73,7 +69,7 @@ where
     }
 
     /// Finish computing digest
-    pub fn finish(self) -> Result<GenericArray<u8, D::OutputSize>, Error> {
+    pub fn finish(self) -> Result<DigestOutput<D>, Error> {
         if self.state == Some(State::Initial) {
             Ok(self.verihash.finish())
         } else {

--- a/rust/src/verihash.rs
+++ b/rust/src/verihash.rs
@@ -5,6 +5,9 @@
 use crate::field::{Tag, WireType};
 use digest::{generic_array::GenericArray, Digest};
 
+/// Output of a given digest algorithm
+pub type DigestOutput<D> = GenericArray<u8, <D as Digest>::OutputSize>;
+
 /// Verihash prefix used by tags (unsigned integer)
 // TODO(tarcieri): support string tags?
 const TAG_PREFIX: u8 = WireType::UInt64.to_u8();
@@ -83,7 +86,7 @@ where
     }
 
     /// Finish computing the digest, returning the output value
-    pub fn finish(self) -> GenericArray<u8, D::OutputSize> {
+    pub fn finish(self) -> DigestOutput<D> {
         self.0.result()
     }
 }


### PR DESCRIPTION
Eliminates direct references to GenericArray