### PR TITLE
codecov.yml: ignore `veriform_derive` files

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -6,3 +6,5 @@ coverage:
         threshold: null
     patch: false
     changes: false
+ignore:
+    - "rust/derive/src/*.rs"


### PR DESCRIPTION
It seems even though this code is exercised by the tests, Tarpaulin doesn't see it, so remove it from coverage checks so it doesn't count against the overall coverage.