### PR TITLE
rust: fix custom derive for message enum variants

### DIFF
--- a/rust/derive/src/message.rs
+++ b/rust/derive/src/message.rs
@@ -114,7 +114,7 @@ impl DeriveEnum {
             WireType::Message => quote! {
                 decoder
                     .peek()
-                    .decode_message(&mut input)?
+                    .decode_message(&mut input)
                     .and_then(|bytes| veriform::Message::decode(decoder, bytes))
                     .map(Self::#name)
                     .map_err(|_| veriform::field::WireType::Message.decoding_error())?

--- a/rust/tests/derive.rs
+++ b/rust/tests/derive.rs
@@ -19,9 +19,15 @@ pub fn new_buffer() -> Buffer {
 }
 
 #[derive(Message, Debug, Eq, PartialEq)]
+pub struct EmptyStruct {}
+
+#[derive(Message, Debug, Eq, PartialEq)]
 pub enum ExampleEnum {
     #[field(tag = 0, wire_type = "bytes", size = 32)]
     BytesVariant([u8; 32]),
+
+    #[field(tag = 1, wire_type = "message")]
+    MessageVariant(EmptyStruct),
 }
 
 impl Default for ExampleEnum {


### PR DESCRIPTION
There was a small bug (unnecessary `?`) and it wasn't covered by the existing custom derive tests.

This commit adds a basic test.