### PR TITLE
rust: fix stack handling in enum message variant custom derive

### DIFF
--- a/rust/derive/src/message.rs
+++ b/rust/derive/src/message.rs
@@ -115,7 +115,12 @@ impl DeriveEnum {
                 decoder
                     .peek()
                     .decode_message(&mut input)
-                    .and_then(|bytes| veriform::Message::decode(decoder, bytes))
+                    .and_then(|bytes| {
+                        decoder.push()?;
+                        let result = veriform::Message::decode(decoder, bytes);
+                        decoder.pop();
+                        result
+                    })
                     .map(Self::#name)
                     .map_err(|_| veriform::field::WireType::Message.decoding_error())?
             },


### PR DESCRIPTION
Previously it wasn't properly pushing a frame onto the decoder's internal stack.