### PR TITLE
rust: implement sequence hashing

### DIFF
--- a/rust/src/decoder/message/decoder.rs
+++ b/rust/src/decoder/message/decoder.rs
@@ -138,14 +138,24 @@ where
         Ok(())
     }
 
-    /// Compute a digest of the message we're decoding.
+    /// Hash a digest of a sequence within this message
+    pub fn hash_sequence_digest(
+        &mut self,
+        tag: Tag,
+        digest: &DigestOutput<D>,
+    ) -> Result<(), Error> {
+        if let Some(hasher) = &mut self.hasher {
+            hasher.hash_sequence_digest(tag, digest)?;
+        }
+
+        Ok(())
+    }
+
+    /// Compute a Verihash digest of the message we're decoding.
     ///
     /// This method is invoked from proc macro-generated code in order to
     /// store the digests of (potentially inner) messages at deserialization
     /// time.
-    ///
-    /// The `finish_digest` method below (which consumes the decoder) is used
-    /// by the decoder itself to compute a Merkle tree over the messages.
     pub fn compute_digest(&mut self) -> Result<Option<DigestOutput<D>>, Error> {
         // Use cached digest if available
         if let Some(digest) = self.cached_digest.clone() {

--- a/rust/src/decoder/traits.rs
+++ b/rust/src/decoder/traits.rs
@@ -32,9 +32,9 @@ where
     D: Digest,
 {
     /// Try to decode a sequence of values of type `T`
-    fn decode_seq<'a>(
-        &mut self,
+    fn decode_seq<'a, 'b>(
+        &'a mut self,
         tag: Tag,
-        input: &mut &'a [u8],
-    ) -> Result<sequence::Iter<'a, T, D>, Error>;
+        input: &mut &'b [u8],
+    ) -> Result<sequence::Iter<'a, 'b, T, D>, Error>;
 }

--- a/rust/src/derive_helpers.rs
+++ b/rust/src/derive_helpers.rs
@@ -33,7 +33,7 @@ where
     D: Digest,
 {
     let mut result = heapless::Vec::new();
-    let seq_iter: sequence::Iter<'_, T, D> = decoder.decode_seq(tag, input)?;
+    let seq_iter: sequence::Iter<'_, '_, T, D> = decoder.decode_seq(tag, input)?;
 
     for elem in seq_iter {
         result.push(elem?).map_err(|_| error::Kind::Decode {

--- a/rust/src/error.rs
+++ b/rust/src/error.rs
@@ -103,6 +103,9 @@ pub enum Kind {
     /// maximum message nesting depth exceeded
     NestingDepth,
 
+    /// nested sequences not presently allowed
+    NestedSequence,
+
     /// field {tag:?} is out-of-order
     Order {
         /// tag of the out-of-order field

--- a/rust/tests/derive.rs
+++ b/rust/tests/derive.rs
@@ -97,10 +97,9 @@ fn struct_round_trip() {
     let decoded = ExampleStruct::decode(&mut decoder, &encoded_buf).unwrap();
 
     // Expected digest
-    // TODO(tarcieri): actually stabilize these!
     example.digest = Some([
-        70, 253, 164, 73, 9, 251, 53, 54, 186, 12, 131, 51, 211, 21, 167, 39, 94, 115, 121, 247,
-        36, 223, 116, 164, 36, 154, 124, 156, 42, 115, 221, 197,
+        184, 86, 174, 227, 32, 40, 78, 107, 138, 228, 168, 208, 186, 189, 128, 164, 210, 15, 126,
+        220, 90, 4, 255, 19, 230, 230, 211, 218, 188, 104, 230, 87,
     ]);
 
     assert_eq!(example, decoded);


### PR DESCRIPTION
This commit actually properly wires up sequence hashing, computing digests of sequences and then hashing them into message digests.

With this, hashing support should be largely complete aside from the handful of type combinations which aren't wired up yet.