### PR TITLE
rust: ensure encoded/decoded strings are ASCII

### DIFF
--- a/rust/src/decoder/decodable.rs
+++ b/rust/src/decoder/decodable.rs
@@ -6,6 +6,7 @@ use crate::{
     error::{self, Error},
     field::WireType,
     message::Element,
+    string,
 };
 use core::str;
 
@@ -54,12 +55,12 @@ pub trait Decodable {
     /// Decode an expected `string` field, returning an error for anything else
     fn decode_string<'a>(&mut self, input: &mut &'a [u8]) -> Result<&'a str, Error> {
         let bytes = self.decode_dynamically_sized_value(WireType::String, input)?;
-        str::from_utf8(bytes).map_err(|e| {
-            error::Kind::Utf8 {
-                valid_up_to: e.valid_up_to(),
-            }
-            .into()
-        })
+
+        let s = str::from_utf8(bytes).map_err(|e| error::Kind::Utf8 {
+            valid_up_to: e.valid_up_to(),
+        })?;
+
+        string::ensure_canonical(s)
     }
 
     /// Decode an expected `message` field, returning an error for anything else

--- a/rust/src/decoder/message/hasher.rs
+++ b/rust/src/decoder/message/hasher.rs
@@ -250,8 +250,6 @@ impl State {
                 }
             }
             State::String { remaining } => {
-                // TODO(tarcieri): use `unicode-normalization`?
-
                 if wire_type != WireType::String || remaining - bytes.len() != new_remaining {
                     return Err(error::Kind::Hashing.into());
                 }

--- a/rust/src/decoder/sequence/hasher.rs
+++ b/rust/src/decoder/sequence/hasher.rs
@@ -196,7 +196,6 @@ impl State {
                 }
             }
             State::String { remaining } => {
-                // TODO(tarcieri): use `unicode-normalization`?
                 if wire_type != WireType::String || remaining - bytes.len() != new_remaining {
                     return Err(error::Kind::Hashing.into());
                 }

--- a/rust/src/encoder.rs
+++ b/rust/src/encoder.rs
@@ -4,6 +4,7 @@ use crate::{
     error::{self, Error},
     field::{Header, Tag, WireType},
     message::Message,
+    string,
 };
 
 /// Veriform encoder
@@ -101,6 +102,7 @@ impl<'a> Encoder<'a> {
 
     /// Write a field containing a string
     pub fn string(&mut self, tag: Tag, critical: bool, string: &str) -> Result<(), Error> {
+        string::ensure_canonical(string)?;
         self.write_header(tag, critical, WireType::String)?;
         self.write_value(string.as_bytes())
     }

--- a/rust/src/error.rs
+++ b/rust/src/error.rs
@@ -133,6 +133,9 @@ pub enum Kind {
         wanted: WireType,
     },
 
+    /// string contains non-normalized Unicode
+    UnicodeNormalization,
+
     /// malformed UTF-8 encountered at byte: {valid_up_to:?}
     Utf8 {
         /// byte at which UTF-8 encoding failed

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -24,6 +24,7 @@ pub mod encoder;
 pub mod error;
 pub mod field;
 pub mod message;
+mod string;
 mod verihash;
 
 #[cfg(feature = "veriform_derive")]

--- a/rust/src/string.rs
+++ b/rust/src/string.rs
@@ -1,0 +1,21 @@
+//! String support
+
+// TODO(tarcieri): use `unicode-normalization` when it fully supports `no_std`. See:
+// <https://github.com/unicode-rs/unicode-normalization/issues/58>
+
+use crate::error::{self, Error};
+
+/// Check if a string is canonical.
+///
+/// We presently limit strings to the ASCII range, but in the future this
+/// should be relaxed to allow any UTF-8 string containing normalized Unicode
+/// (NOTE: exactly what constitutes canonical/normalized Unicode, e.g. NFC vs
+/// NFD, is TBD)
+pub fn ensure_canonical(s: &str) -> Result<&str, Error> {
+    // TODO(tarcieri): replace this with e.g. `unicode_normalization::is_nfc_quick()`
+    if s.is_ascii() {
+        Ok(s)
+    } else {
+        Err(error::Kind::UnicodeNormalization.into())
+    }
+}


### PR DESCRIPTION
This is a stopgap until the issue of Unicode normalization can be properly addressed (e.g. should we check strings are NFC or NFD?)

Furthermore, the `unicode-normalization` crate doesn't support `no_std` environments (sans liballoc yet):

https://github.com/unicode-rs/unicode-normalization/issues/58

Ensuring all strings are ASCII, while perhaps overly restrictive for now, will ensure all documents produced today are canonical in a way that's forward compatible with canonical Unicode.