### PR TITLE
veriform.rs v0.1.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -973,7 +973,7 @@ checksum = "9fde2f6a4bea1d6e007c4ad38c6839fa71cbb63b6dbf5b595aa38dc9b1093c11"
 
 [[package]]
 name = "veriform"
-version = "0.0.1"
+version = "0.1.0"
 dependencies = [
  "digest",
  "displaydoc",
@@ -988,7 +988,7 @@ dependencies = [
 
 [[package]]
 name = "veriform_derive"
-version = "0.0.0"
+version = "0.1.0"
 dependencies = [
  "darling",
  "proc-macro2",

--- a/rust/CHANGES.md
+++ b/rust/CHANGES.md
@@ -4,5 +4,46 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.1.0 (2020-05-21)
+### Added
+- Initial Verihash "Merkleized" message hashing support ([#120], [#124], [#125], [#128], [#145])
+- Custom derive support for `veriform::Message` ([#131], [#135], [#136], [#141])
+- `Decode*` traits ([#117])
+- `log` feature for tracing message decoding ([#117])
+- Builtin types: `Timestamp` and `Uuid` ([#98])
+
+### Changed
+- Split error type into `veriform::error::{Error, Kind}` ([#127], [#129])
+- Ensure encoded/decoded strings are ASCII ([#146])
+- Make encoding result immutable ([#105])
+- MSRV 1.40+ ([#91])
+- Extract `Decodable` trait ([#84])
+
+### Fixed
+- Sequence decoding ([#86], [#96])
+
+[#146]: https://github.com/iqlusioninc/veriform/pull/146
+[#145]: https://github.com/iqlusioninc/veriform/pull/145
+[#141]: https://github.com/iqlusioninc/veriform/pull/141
+[#136]: https://github.com/iqlusioninc/veriform/pull/136
+[#135]: https://github.com/iqlusioninc/veriform/pull/135
+[#131]: https://github.com/iqlusioninc/veriform/pull/131
+[#129]: https://github.com/iqlusioninc/veriform/pull/129
+[#128]: https://github.com/iqlusioninc/veriform/pull/128
+[#127]: https://github.com/iqlusioninc/veriform/pull/127
+[#125]: https://github.com/iqlusioninc/veriform/pull/125
+[#124]: https://github.com/iqlusioninc/veriform/pull/124
+[#120]: https://github.com/iqlusioninc/veriform/pull/120
+[#117]: https://github.com/iqlusioninc/veriform/pull/117
+[#105]: https://github.com/iqlusioninc/veriform/pull/105
+[#98]: https://github.com/iqlusioninc/veriform/pull/98
+[#96]: https://github.com/iqlusioninc/veriform/pull/96
+[#91]: https://github.com/iqlusioninc/veriform/pull/91
+[#86]: https://github.com/iqlusioninc/veriform/pull/86
+[#84]: https://github.com/iqlusioninc/veriform/pull/84
+
+### Fixed
+- Sequence decoding ([#86], [#96])
+
 ## 0.0.1 (2020-02-25)
 - Initial release

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name        = "veriform"
 description = "Cryptographically verifiable data serialization format inspired by Protocol Buffers"
-version     = "0.0.1"
+version     = "0.1.0"
 license     = "Apache-2.0"
 authors     = ["Tony Arcieri <tony@iqlusion.io>"]
 homepage    = "https://github.com/iqlusioninc/veriform/"
@@ -19,7 +19,7 @@ log = { version = "0.4", optional = true }
 sha2 = { version = "0.8", optional = true, default-features = false }
 tai64 = { version = "3", optional = true, default-features = false }
 uuid = { version = "0.8", optional = true, default-features = false }
-veriform_derive = { version = "0", optional = true, path = "derive" }
+veriform_derive = { version = "0.1", optional = true, path = "derive" }
 vint64 = { version = "1", path = "vint64" }
 
 [features]

--- a/rust/derive/Cargo.toml
+++ b/rust/derive/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name        = "veriform_derive"
 description = "Custom derive for the Veriform verifiable data serialization format"
-version     = "0.0.0"
+version     = "0.1.0"
 license     = "Apache-2.0"
 authors     = ["Tony Arcieri <tony@iqlusion.io>"]
 homepage    = "https://github.com/iqlusioninc/veriform/"

--- a/rust/derive/src/lib.rs
+++ b/rust/derive/src/lib.rs
@@ -21,6 +21,18 @@ use synstructure::decl_derive;
 
 decl_derive!(
     [Message, attributes(digest, field)] =>
-    /// Derive the `Message` trait for an enum or struct
+    /// Derive the `Message` trait for an `enum` or `struct`.
+    ///
+    /// When using this macro, every field in a `struct` or every variant of an
+    /// `enum` must have one of the following attributes:
+    ///
+    /// - `#[field(...)]`: schema information for a field in a Veriform message
+    /// - `#[digest(...)]`: (`struct` only) support for storing a computed
+    ///   Verihash digest inside of a `struct` containing message fields.
+    ///   The `digest` field MUST be the last in the message.
+    ///
+    /// See [`tests/derive.rs`] for usage examples.
+    ///
+    /// [`tests/derive.rs`]: https://github.com/iqlusioninc/veriform/blob/develop/rust/tests/derive.rs
     message::derive
 );

--- a/rust/derive/src/message.rs
+++ b/rust/derive/src/message.rs
@@ -187,6 +187,7 @@ impl DeriveEnum {
 }
 
 /// Derive `Message` on a struct
+// TODO(tarcieri): make sure tags are in the right order and digest is the last field
 struct DeriveStruct {
     /// Body of `Message::decode()` in-progress for a struct
     decode_body: TokenStream,

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -3,10 +3,32 @@
 //!
 //! This crate provides a `no_std`-friendly implementation of the format
 //! with a zero-copy pull parser.
+//!
+//! For more information on Veriform, see the work-in-progress specification:
+//! <https://github.com/iqlusioninc/veriform/blob/develop/spec/draft-veriform-spec.md>
+//!
+//! # Usage
+//!
+//! The main API for encoding and decoding Veriform messages is the
+//! [`Message`] trait. When the `veriform_derive` feature of this crate
+//! is enabled, custom derive is available for this trait for both structs
+//! and enums.
+//!
+//! See the documentation for the `Message` proc macro for more information.
+//!
+//! # Built-in Types
+//!
+//! Veriform has a small "standard library" of so-called "built-in types" which
+//! are serialized using message syntax, but in a consistent way which allows
+//! different programming language environments to use the best-available
+//! native representation for these types.
+//!
+//! - `Timestamp`: date/time as represented in International Atomic Time (TAI)
+//! - `Uuid`: universally unique identifier
 
 #![no_std]
 #![cfg_attr(docsrs, feature(doc_cfg))]
-#![doc(html_root_url = "https://docs.rs/veriform/0.0.1")]
+#![doc(html_root_url = "https://docs.rs/veriform/0.1.0")]
 #![forbid(unsafe_code)]
 #![warn(missing_docs, rust_2018_idioms, unused_qualifications)]
 


### PR DESCRIPTION
### Added
- Initial Verihash "Merkleized" message hashing support ([#120], [#124], [#125], [#128], [#145])
- Custom derive support for `veriform::Message` ([#131], [#135], [#136], [#141])
- `Decode*` traits ([#117])
- `log` feature for tracing message decoding ([#117])
- Builtin types: `Timestamp` and `Uuid` ([#98])

### Changed
- Split error type into `veriform::error::{Error, Kind}` ([#127], [#129])
- Ensure encoded/decoded strings are ASCII ([#146])
- Make encoding result immutable ([#105])
- MSRV 1.40+ ([#91])
- Extract `Decodable` trait ([#84])

### Fixed
- Sequence decoding ([#86], [#96])

[#146]: https://github.com/iqlusioninc/veriform/pull/146
[#145]: https://github.com/iqlusioninc/veriform/pull/145
[#141]: https://github.com/iqlusioninc/veriform/pull/141
[#136]: https://github.com/iqlusioninc/veriform/pull/136
[#135]: https://github.com/iqlusioninc/veriform/pull/135
[#131]: https://github.com/iqlusioninc/veriform/pull/131
[#129]: https://github.com/iqlusioninc/veriform/pull/129
[#128]: https://github.com/iqlusioninc/veriform/pull/128
[#127]: https://github.com/iqlusioninc/veriform/pull/127
[#125]: https://github.com/iqlusioninc/veriform/pull/125
[#124]: https://github.com/iqlusioninc/veriform/pull/124
[#120]: https://github.com/iqlusioninc/veriform/pull/120
[#117]: https://github.com/iqlusioninc/veriform/pull/117
[#105]: https://github.com/iqlusioninc/veriform/pull/105
[#98]: https://github.com/iqlusioninc/veriform/pull/98
[#96]: https://github.com/iqlusioninc/veriform/pull/96
[#91]: https://github.com/iqlusioninc/veriform/pull/91
[#86]: https://github.com/iqlusioninc/veriform/pull/86
[#84]: https://github.com/iqlusioninc/veriform/pull/84