### PR TITLE
rust: unify enum and struct decoding

### DIFF
--- a/rust/derive/src/field.rs
+++ b/rust/derive/src/field.rs
@@ -50,7 +50,7 @@ impl Attrs {
 }
 
 /// Wire type identifiers for Veriform types
-#[derive(Copy, Clone, Debug)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
 pub(crate) enum WireType {
     /// Boolean values - these are actually modeled as two different wire type
     /// identifiers (0 and 1) but consolidated for the purposes of this macro
@@ -104,6 +104,11 @@ impl WireType {
         };
 
         Some(ty)
+    }
+
+    /// Is the underlying Rust type to decode a reference type?
+    pub fn is_ref_type(self) -> bool {
+        self == WireType::Bytes || self == WireType::String
     }
 
     /// Is this [`WireType`] a `Message`?

--- a/rust/src/decoder/decodable.rs
+++ b/rust/src/decoder/decodable.rs
@@ -11,7 +11,7 @@ use crate::{
 use core::str;
 
 /// Common functionality between the `message` and `sequence` decoders
-pub trait Decodable {
+pub(crate) trait Decodable {
     /// Process the given input data, advancing the slice for the amount of
     /// data processed, and returning any decoded events.
     fn decode<'a>(&mut self, input: &mut &'a [u8]) -> Result<Option<Event<'a>>, Error>;

--- a/rust/src/decoder/event.rs
+++ b/rust/src/decoder/event.rs
@@ -4,7 +4,7 @@ use crate::field::{Header, WireType};
 
 /// Events emitted by Veriform's decoder
 #[derive(Clone, Debug, Eq, PartialEq)]
-pub enum Event<'a> {
+pub(crate) enum Event<'a> {
     /// Consumed field header with the given tag and wire type
     FieldHeader(Header),
 

--- a/rust/src/decoder/message.rs
+++ b/rust/src/decoder/message.rs
@@ -7,4 +7,4 @@ mod header;
 mod state;
 mod value;
 
-pub use self::decoder::Decoder;
+pub(crate) use self::decoder::Decoder;

--- a/rust/src/decoder/message/decoder.rs
+++ b/rust/src/decoder/message/decoder.rs
@@ -13,7 +13,7 @@ use digest::Digest;
 
 /// Veriform message decoder: streaming zero-copy pull parser which emits
 /// events based on incoming data.
-pub struct Decoder<D: Digest> {
+pub(crate) struct Decoder<D: Digest> {
     /// Last field tag that was decoded (to ensure monotonicity)
     last_tag: Option<Tag>,
 
@@ -43,17 +43,6 @@ where
             hasher: Some(Hasher::new()), // TODO(tarcieri): support for disabling hasher
             cached_digest: None,
         }
-    }
-
-    /// Get the tag (i.e. ID) of the last decoded field header
-    pub fn last_tag(&self) -> Option<Tag> {
-        self.last_tag
-    }
-
-    /// Get the current position (i.e. number of bytes processed) in the
-    /// message being decoded
-    pub fn position(&self) -> usize {
-        self.position
     }
 
     /// Decode an expected field header, returning an error for anything else

--- a/rust/src/decoder/message/hasher.rs
+++ b/rust/src/decoder/message/hasher.rs
@@ -24,7 +24,7 @@ use digest::Digest;
 ///
 /// This type computes a hash-based transcript of how a message was
 /// decoded, driven by incoming decoding events.
-pub struct Hasher<D: Digest> {
+pub(super) struct Hasher<D: Digest> {
     /// Verihash hasher
     verihash: verihash::Hasher<D>,
 

--- a/rust/src/decoder/sequence.rs
+++ b/rust/src/decoder/sequence.rs
@@ -5,4 +5,6 @@ mod hasher;
 mod iter;
 mod state;
 
-pub use self::{decoder::Decoder, iter::Iter};
+pub use self::iter::Iter;
+
+pub(crate) use self::decoder::Decoder;

--- a/rust/src/decoder/sequence/decoder.rs
+++ b/rust/src/decoder/sequence/decoder.rs
@@ -11,7 +11,7 @@ use crate::{
 use digest::Digest;
 
 /// Sequence decoder
-pub struct Decoder<D: Digest> {
+pub(crate) struct Decoder<D: Digest> {
     /// Wire type contained in this sequence
     wire_type: WireType,
 

--- a/rust/src/decoder/sequence/hasher.rs
+++ b/rust/src/decoder/sequence/hasher.rs
@@ -19,7 +19,7 @@ use digest::Digest;
 ///
 /// This type computes a hash-based transcript of how a message was
 /// decoded, driven by incoming decoding events.
-pub struct Hasher<D: Digest> {
+pub(super) struct Hasher<D: Digest> {
     /// Verihash hasher
     verihash: verihash::Hasher<D>,
 

--- a/rust/src/derive_helpers.rs
+++ b/rust/src/derive_helpers.rs
@@ -5,7 +5,7 @@ use crate::{
     decoder::{DecodeSeq, Decoder},
     encoder::Encoder,
     error::{self, Error},
-    field::{Tag, WireType},
+    field::{self, Tag, WireType},
     message::{Element, Message},
 };
 use digest::Digest;
@@ -72,6 +72,12 @@ where
         body_len,
         seq.iter().map(|elem| elem as &dyn Message),
     )
+}
+
+/// Decode tag (which identifies an enum variant)
+pub fn decode_tag(mut input: &[u8]) -> Result<Tag, Error> {
+    let header = vint64::decode(&mut input)?;
+    Ok(field::Header::from(header).tag)
 }
 
 /// Unknown tag in enum

--- a/rust/src/error.rs
+++ b/rust/src/error.rs
@@ -60,6 +60,12 @@ impl Display for Error {
     }
 }
 
+impl From<vint64::Error> for Error {
+    fn from(_: vint64::Error) -> Error {
+        Kind::VInt64.into()
+    }
+}
+
 #[cfg(feature = "std")]
 impl std::error::Error for Error {}
 


### PR DESCRIPTION
Changes the custom derive for enums to use the `Decode` and `DecodeRef` traits, i.e. the same API used to decode structs.

With this change, a considerable amount of the existing API service can (and has) been made private, which unlocks a lot of interesting refactoring possibilities.