### PR TITLE
rust: documentation improvements

### DIFF
--- a/rust/derive/src/digest.rs
+++ b/rust/derive/src/digest.rs
@@ -6,7 +6,25 @@
 use darling::FromField;
 use std::str::FromStr;
 
-/// Parsed `#[digest(...)]` attribute
+/// Parsed `#[digest(...)]` attribute.
+///
+/// At present, the only meaningful usage of this attribute is:
+///
+/// ```text
+/// #[digest(alg = "sha256")]
+/// digest: Option<[u8; 32]>
+/// ```
+///
+/// This indicates that the given field of a struct should be populated with
+/// the SHA-256 Verihash digest of a message.
+///
+/// This attribute is presently ignored at encoding time, but recommended
+/// (and possibly required in the future) to be set to `None`.
+///
+/// If you'd like, you can use the [`veriform::Sha256Digest`] type alias
+/// instead of `[u8; 32]`.
+///
+/// [`veriform::Sha256Digest`]: https://docs.rs/veriform/latest/veriform/type.Sha256Digest.html
 #[derive(Debug, FromField)]
 #[darling(attributes(digest))]
 pub(crate) struct Attrs {

--- a/rust/derive/src/field.rs
+++ b/rust/derive/src/field.rs
@@ -5,14 +5,35 @@ use proc_macro2::TokenStream;
 use quote::quote;
 use syn::Ident;
 
-/// Parsed `#[field(...)]` attribute
+/// Parsed `#[field(...)]` attribute.
+///
+/// When deriving the [`Message`] trait, every enum variant or field of a
+/// struct MUST be tagged as a `field`.
+///
+/// # Example
+///
+/// ```ignore
+/// #[derive(Message, Debug, Eq, PartialEq)]
+/// pub struct ExampleMessageA {
+///     #[field(tag = 0, wire_type = "uint64", critical = true)]
+///     pub uint64_field: u64,
+///
+///     #[field(tag = 1, wire_type = "sint64")]
+///     pub sint64_field: i64,
+///
+///     #[field(tag = 2, wire_type = "sequence", critical = true, max = 8)]
+///     pub msg_sequence_field: Vec<ExampleMessageB>,
+/// }
+/// ```
+///
+/// [`Message`]: https://docs.rs/veriform/latest/veriform/derive.Message.html
 #[derive(Debug, FromField, FromVariant)]
 #[darling(attributes(field))]
 pub(crate) struct Attrs {
     /// Tag which identifies the field
     tag: u64,
 
-    /// Wire type of the field
+    /// Wire type of the field. See [`WireType`] for the available type names.
     wire_type: Ident,
 
     /// Is this field critical?
@@ -52,26 +73,27 @@ impl Attrs {
 /// Wire type identifiers for Veriform types
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
 pub(crate) enum WireType {
-    /// Boolean values - these are actually modeled as two different wire type
-    /// identifiers (0 and 1) but consolidated for the purposes of this macro
+    /// `bool`: boolean values - these are actually modeled as two different
+    /// wire type identifiers (0 and 1) but consolidated for the purposes of
+    /// this macro
     Bool,
 
-    /// 64-bit unsigned integer
+    /// `uint64`: 64-bit unsigned integer
     UInt64,
 
-    /// 64-bit (zigzag) signed integer
+    /// `sint64`: 64-bit (zigzag) signed integer
     SInt64,
 
-    /// Binary data
+    /// `bytes`: binary data
     Bytes,
 
-    /// Unicode string
+    /// `string`: Unicode string
     String,
 
-    /// Nested Veriform message
+    /// `message`: nested Veriform message
     Message,
 
-    /// Sequences
+    /// `sequence`: sequences of other types (a.k.a. lists, arrays)
     Sequence,
 }
 

--- a/rust/derive/src/lib.rs
+++ b/rust/derive/src/lib.rs
@@ -21,18 +21,23 @@ use synstructure::decl_derive;
 
 decl_derive!(
     [Message, attributes(digest, field)] =>
-    /// Derive the `Message` trait for an `enum` or `struct`.
+    /// Derive the [`Message`] trait for an `enum` or `struct`.
     ///
     /// When using this macro, every field in a `struct` or every variant of an
     /// `enum` must have one of the following attributes:
     ///
-    /// - `#[field(...)]`: schema information for a field in a Veriform message
+    /// - `#[field(...)]`: schema information for a field in a Veriform message.
+    ///   For more information on the syntax, see the [`field::Attrs`] docs.
     /// - `#[digest(...)]`: (`struct` only) support for storing a computed
     ///   Verihash digest inside of a `struct` containing message fields.
-    ///   The `digest` field MUST be the last in the message.
+    ///   The `digest` field MUST be the last in the message. For more
+    ///   information, see the [`digest::Attrs`] docs.
     ///
     /// See [`tests/derive.rs`] for usage examples.
     ///
+    /// [`Message`]: https://docs.rs/veriform/latest/veriform/message/trait.Message.html
+    /// [`field::Attrs`]: https://docs.rs/veriform_derive/latest/veriform_derive/field/struct.Attrs.html
+    /// [`digest::Attrs`]: https://docs.rs/veriform_derive/latest/veriform_derive/digest/struct.Attrs.html
     /// [`tests/derive.rs`]: https://github.com/iqlusioninc/veriform/blob/develop/rust/tests/derive.rs
     message::derive
 );

--- a/rust/src/decoder.rs
+++ b/rust/src/decoder.rs
@@ -25,7 +25,12 @@ use crate::{
 use digest::Digest;
 use heapless::consts::U16;
 
-/// Veriform decoder
+/// Veriform decoder.
+///
+/// This type contains message decoding state and also performs Verihash
+/// computation.
+///
+/// It's intended to be used in conjunction with the [`Message`] trait.
 pub struct Decoder<D: Digest> {
     /// Stack of message decoders (max nesting depth 16)
     stack: heapless::Vec<message::Decoder<D>, U16>,

--- a/rust/src/derive_helpers.rs
+++ b/rust/src/derive_helpers.rs
@@ -90,9 +90,9 @@ pub fn unknown_tag(tag: Tag) -> Error {
 }
 
 /// Fallible version of the `Extend` trait used for consuming Veriform
-/// sequences but with potential `max` limits (e.g. `heapless::Vec` size)
+/// sequences but with potential max limits (e.g. `heapless::Vec` size)
 pub trait TryExtend<A> {
-    /// Try to extend this type using the given iterator, returnin an error if
+    /// Try to extend this type using the given iterator, returning an error if
     /// capacity in the underlying buffer is exceeded
     fn try_extend<T>(&mut self, iter: T) -> Result<(), ()>
     where

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -14,8 +14,6 @@
 //! is enabled, custom derive is available for this trait for both structs
 //! and enums.
 //!
-//! See the documentation for the `Message` proc macro for more information.
-//!
 //! # Built-in Types
 //!
 //! Veriform has a small "standard library" of so-called "built-in types" which
@@ -23,14 +21,22 @@
 //! different programming language environments to use the best-available
 //! native representation for these types.
 //!
-//! - `Timestamp`: date/time as represented in International Atomic Time (TAI)
-//! - `Uuid`: universally unique identifier
+//! - [`Timestamp`]: date/time as represented in International Atomic Time (TAI)
+//! - [`Uuid`]: universally unique identifier
+//!
+//! [`Timestamp`]: https://docs.rs/veriform/latest/veriform/builtins/struct.Timestamp.html
+//! [`Uuid`]: https://docs.rs/veriform/latest/veriform/builtins/struct.Uuid.html
 
 #![no_std]
 #![cfg_attr(docsrs, feature(doc_cfg))]
 #![doc(html_root_url = "https://docs.rs/veriform/0.1.0")]
 #![forbid(unsafe_code)]
-#![warn(missing_docs, rust_2018_idioms, unused_qualifications)]
+#![warn(
+    missing_docs,
+    rust_2018_idioms,
+    unused_qualifications,
+    intra_doc_link_resolution_failure
+)]
 
 #[cfg(feature = "alloc")]
 #[macro_use]

--- a/rust/src/message.rs
+++ b/rust/src/message.rs
@@ -11,23 +11,15 @@ use digest::Digest;
 #[cfg(feature = "alloc")]
 use alloc::vec::Vec;
 
-/// Elements of a message (used for errors)
-#[derive(Copy, Clone, Debug, Eq, PartialEq)]
-pub enum Element {
-    /// Length delimiters for dynamically sized fields
-    LengthDelimiter,
-
-    /// Headers of sequences
-    SequenceHeader,
-
-    /// Tags identify the types of fields
-    Tag,
-
-    /// Field values (i.e. inside the body of a field value)
-    Value,
-}
-
-/// Veriform messages
+/// Veriform messages.
+///
+/// This trait provides the primary API for encoding/decoding messages as
+/// Veriform.
+///
+/// It's not intended to be implemented directly, but instead derived using
+/// the [`veriform::Message`] procedural macro.
+///
+/// [`veriform::Message`]: https://docs.rs/veriform/latest/veriform/derive.Message.html
 pub trait Message {
     /// Decode a Veriform message contained in the provided slice using the
     /// given [`Decoder`].
@@ -51,4 +43,20 @@ pub trait Message {
         self.encode(&mut encoded)?;
         Ok(encoded)
     }
+}
+
+/// Elements of a message (used for errors)
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+pub enum Element {
+    /// Length delimiters for dynamically sized fields
+    LengthDelimiter,
+
+    /// Headers of sequences
+    SequenceHeader,
+
+    /// Tags identify the types of fields
+    Tag,
+
+    /// Field values (i.e. inside the body of a field value)
+    Value,
 }


### PR DESCRIPTION
Adds more documentation about the proc macros and certain core library features including several links to docs.rs.