### PR TITLE
veriform.rs v0.2.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -973,7 +973,7 @@ checksum = "9fde2f6a4bea1d6e007c4ad38c6839fa71cbb63b6dbf5b595aa38dc9b1093c11"
 
 [[package]]
 name = "veriform"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "digest",
  "displaydoc",
@@ -988,7 +988,7 @@ dependencies = [
 
 [[package]]
 name = "veriform_derive"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "darling",
  "proc-macro2",

--- a/rust/CHANGES.md
+++ b/rust/CHANGES.md
@@ -4,6 +4,19 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.2.0 (2020-05-22)
+### Added
+- Documentation improvements ([#150])
+
+### Changed
+- Unify `enum` and `struct` decoding ([#149])
+
+### Removed
+- Massive amounts of API surface ([#149])
+
+[#150]: https://github.com/iqlusioninc/veriform/pull/150
+[#149]: https://github.com/iqlusioninc/veriform/pull/149
+
 ## 0.1.0 (2020-05-21)
 ### Added
 - Initial Verihash "Merkleized" message hashing support ([#120], [#124], [#125], [#128], [#145])

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name        = "veriform"
 description = "Cryptographically verifiable data serialization format inspired by Protocol Buffers"
-version     = "0.1.0"
+version     = "0.2.0"
 license     = "Apache-2.0"
 authors     = ["Tony Arcieri <tony@iqlusion.io>"]
 homepage    = "https://github.com/iqlusioninc/veriform/"
@@ -19,7 +19,7 @@ log = { version = "0.4", optional = true }
 sha2 = { version = "0.8", optional = true, default-features = false }
 tai64 = { version = "3", optional = true, default-features = false }
 uuid = { version = "0.8", optional = true, default-features = false }
-veriform_derive = { version = "0.1", optional = true, path = "derive" }
+veriform_derive = { version = "0.2", optional = true, path = "derive" }
 vint64 = { version = "1", path = "vint64" }
 
 [features]

--- a/rust/derive/Cargo.toml
+++ b/rust/derive/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name        = "veriform_derive"
 description = "Custom derive for the Veriform verifiable data serialization format"
-version     = "0.1.0"
+version     = "0.2.0"
 license     = "Apache-2.0"
 authors     = ["Tony Arcieri <tony@iqlusion.io>"]
 homepage    = "https://github.com/iqlusioninc/veriform/"

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -29,7 +29,7 @@
 
 #![no_std]
 #![cfg_attr(docsrs, feature(doc_cfg))]
-#![doc(html_root_url = "https://docs.rs/veriform/0.1.0")]
+#![doc(html_root_url = "https://docs.rs/veriform/0.2.0")]
 #![forbid(unsafe_code)]
 #![warn(
     missing_docs,


### PR DESCRIPTION
### Added
- Documentation improvements ([#150])

### Changed
- Unify `enum` and `struct` decoding ([#149])

### Removed
- Massive amounts of API surface ([#149])

[#150]: https://github.com/iqlusioninc/veriform/pull/150
[#149]: https://github.com/iqlusioninc/veriform/pull/149